### PR TITLE
Fixed hand-crafted JS code for IE, tested in IE8 & IE8 as 7

### DIFF
--- a/examples/rts-common.js
+++ b/examples/rts-common.js
@@ -24,7 +24,7 @@ var $hs = {
           return a >= b;
         else
           return a <= b;
-      },
+      }
     },
     Int : { // binary operations supposed to work with 32bit words
       addCarry : function(a, b, c) {
@@ -48,7 +48,7 @@ var $hs = {
       },
       mulIntMayOflo : function(a, b) {
         return a >>> 16 == 0 && b >>> 16 == 0;
-      },
+      }
     },
     modules: {},
     alert: function (str) {
@@ -66,7 +66,7 @@ var $hs = {
     },
     logDebug: function (str) {
         $hs.logAny("DEBUG", str);
-    },
+    }
 }
 
 $hs.Module = function () {};

--- a/examples/rts-plain.js
+++ b/examples/rts-plain.js
@@ -41,7 +41,7 @@ $hs.Func = function(a) {
 };
 $hs.Func.prototype = {
     hscall: $hs.hscall,
-    notEvaluated: false,
+    notEvaluated: false
 };
 
 $hs.Thunk = function() {};

--- a/examples/rts-trampoline.js
+++ b/examples/rts-trampoline.js
@@ -62,7 +62,7 @@ $hs.Func = function(a) {
 };
 $hs.Func.prototype = {
     hscall: $hs.hscall,
-    notEvaluated: false,
+    notEvaluated: false
 };
 
 $hs.Thunk = function() {};


### PR DESCRIPTION
Fixed hand-crafted JS code for IE, tested in IE8 & IE8 as 7

Still broken in IE6
The only problem was a few trailing commas.
