### PR TITLE
Update some dependency upper bounds. optparse-applicative changed a type

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -84,7 +84,7 @@ Library
                    jmacro         >= 0.7      && < 0.8,
                    text           >= 0.11     && < 0.12,
                    wl-pprint-text >= 1.0      && < 1.2,
-                   lens           >= 3.9      && < 4,
+                   lens           >= 3.9      && < 4.1,
                    parsec         >= 3.1      && < 3.2,
                    yaml           >= 0.8      && < 0.9,
                    shelly         >= 1.3      && < 1.4,
@@ -125,7 +125,7 @@ Executable ghcjs
                     filepath,
                     bytestring          >= 0.9  && < 0.11,
                     Cabal,
-                    optparse-applicative >= 0.5 && < 0.6
+                    optparse-applicative >= 0.6 && < 0.9
     GHC-Options:    -O -fno-warn-orphans -rtsopts -with-rtsopts=-K256m -with-rtsopts=-N -auto-all -threaded
 
 Executable ghcjs-pkg
@@ -167,7 +167,7 @@ Executable ghcjs-boot
                       system-filepath      >= 0.4  && < 0.5,
                       shelly               >= 1.3  && < 1.4,
                       system-fileio        >= 0.3  && < 0.4,
-                      optparse-applicative >= 0.5  && < 0.6
+                      optparse-applicative >= 0.6  && < 0.9
 
 test-suite test
     type:             exitcode-stdio-1.0

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -179,7 +179,7 @@ optParser = GhcjsSettings
             <*> optStr ( long "use-base" )
 
 optStr :: Mod OptionFields (Maybe String) -> Parser (Maybe String)
-optStr m = nullOption $ value Nothing <> reader (Right . str)  <> m
+optStr m = nullOption $ value Nothing <> reader (ReadM . Right . str)  <> m
 
 main :: IO ()
 main =


### PR DESCRIPTION
signature so I have updated the lower bound to exclude the old one.
