### PR TITLE
add with-cabal, with-compiler to ghcjs-boot

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,6 +92,8 @@ Check that you have the correct version of `GHCJS` in your PATH:
 Build the base libraries for `GHCJS`:
 
     $ ghcjs-boot --init
+    or
+    $ ghcjs-boot --init --with-cabal cabal-js # if you used --program-suffix=-js earlier
 
 
 Usage

--- a/src-bin/Boot.hs
+++ b/src-bin/Boot.hs
@@ -555,7 +555,7 @@ installExtraPackages s = sub $ do
   echo "installing Cabal and extra packages"
   cd "extra"
   installExtra (cabalBoot s) =<< readExtra "extra0"
-  sub (cd ("cabal" </> "Cabal") >> cabal s ["clean"])
+  sub (cd ("cabal" </> "Cabal") >> cabalClean s)
   cabal s $ ["install", "--ghcjs", "./cabal/Cabal", "--only-dependencies"]
   removeFakes
   cabal s $ ["install", "--ghcjs", "./cabal/Cabal"] ++ cabalFlags False s
@@ -598,7 +598,7 @@ preparePackage s pkg = sub $ do
     echo ("generating configure script for " <> T.pack pkg)
     autoreconf []
   rm_rf "dist"
---  cabal s ["clean"]
+--  cabalClean s
 
 fixRtsConf :: Text -> Text -> Text -> Text
 fixRtsConf incl lib conf = T.unlines . map fixLine . T.lines $ conf
@@ -708,6 +708,10 @@ cabal     s xs = run_ prog args
     where
     prog = fromText $ withCabal s
     args = xs ++ ["--with-compiler", withCompiler s]
+
+cabalClean :: BootSettings -> Sh ()
+cabalClean s = run_ prog ["clean"]
+    where prog = fromText $ withCabal s
 
 #ifdef WINDOWS
 bash cmd xs = run_ "bash" ["-c", T.unwords (map escapeArg (cmd:xs))]


### PR DESCRIPTION
Addresses #154 and #160 - ghcjs-boot now accepts the following new
options:

  --with-cabal - specify an alternative name for the `cabal` program
    to be used while booting. Useful if you used --program-suffix when
    compiling a ghcjs-aware cabal-install.

  --with-compiler - specify an alternative name for the `ghcjs` program.
    I'm not 100% sure why this is helpful, but adding this option should
    fix #154 by ensuring that `ghcjs` is used as the default, regardless
    of the user's cabal configuration.
