### PR TITLE
Make update_archives.sh compatible with older versions of git

### DIFF
--- a/utils/update_archives.sh
+++ b/utils/update_archives.sh
@@ -112,6 +112,8 @@ then
     exit 1
 fi
 
+# This is a simulation of git symbolic-ref --short -q HEAD, which doesn't work with
+# older versions of git.  The --short option is supported by git-1.9.1.
 if BRANCH=$(git symbolic-ref -q HEAD | sed 's:^.*/\([^/]*\)$:\1:')
 then
     echo "using git branch: ${BRANCH}"


### PR DESCRIPTION
This should simulate the behavior of git symbolic-ref --short -q HEAD by stripping everything up to the last slash off the result of git symbolic-ref -q HEAD.  I found that building a newer git for Ubuntu precise was more difficult and dangerous than you might expect, as it requires a newer dpkg, and the latest dpkg fails to build.
