### PR TITLE
Dockerfile to automatically build ghcjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM haskell:7.8
+
+ENV DEBIAN_FRONTENT non-interactive
+
+ADD . ./ghcjs
+
+RUN apt-get update \
+    && apt-get -y install build-essential git zlib1g-dev libtinfo-dev libgmp-dev autoconf curl
+
+RUN curl -sL https://deb.nodesource.com/setup | bash - \
+    && apt-get install -y nodejs
+
+RUN git clone https://github.com/ghcjs/cabal.git \
+    && cd cabal \
+    && git checkout ghcjs \
+    && cabal update \
+    && cabal install ./Cabal ./cabal-install
+
+
+RUN git clone https://github.com/ghcjs/ghcjs-prim.git \
+    && cabal update \
+    && cabal install --reorder-goals --max-backjumps=1 ./ghcjs ./ghcjs-prim
+
+ENV PATH /root/.cabal/bin:/opt/ghc/7.8.3/bin:/opt/cabal/1.20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN which ghcjs-pkg
+
+RUN ghcjs-boot --dev
+CMD ["/bin/bash"]
+
+


### PR DESCRIPTION
Hi, I've made a Dockerfile to build ghcjs automatically and quickly do expecriments with a clean environment - once a docker image is built it's easy to spin up a new container for testing. Given building ghcjs takes a while and (for me at least) sometimes fails, I find it nice to be able to work against a stable build on docker hub.

I hope you find it useful - I need some help to make this into a good patch, see below. 

So far for the good news ;). This falls somewhere between a pull request and an issue.  This dockerfile (with ghcjs cloned from git instead of locally) built corronectly on November 18. Without changing the Dockerfile,  (I changed the readme in the original project) the build broke on the 21st.
cabal can't make a build plan:
Step 6 : RUN git clone https://github.com/ghcjs/ghcjs-prim.git     && cabal update     && cabal install --reorder-goals --max-backjumps=1 ./ghcjs ./ghcjs-prim
 ---> Running in 46b89abd0c04
Cloning into 'ghcjs-prim'...
Downloading the latest package list from hackage.haskell.org
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: ghcjs-0.1.0 (user goal)
trying: parsec-3.1.7/installed-87c... (dependency of ghcjs-0.1.0)
next goal: wl-pprint-text (dependency of ghcjs-0.1.0)
rejecting: wl-pprint-text-1.1.0.2 (conflict: parsec =>
text==1.2.0.0/installed-ffa..., wl-pprint-text => text>=0.11.0.0 && <1.2.0.0)
rejecting: wl-pprint-text-1.1.0.1 (conflict: parsec =>
text==1.2.0.0/installed-ffa..., wl-pprint-text => text>=0.11.0.0 && <1.1.0.0)
rejecting: wl-pprint-text-1.1.0.0 (conflict: parsec =>
text==1.2.0.0/installed-ffa..., wl-pprint-text => text>=0.11.0.0 && <0.12.0.0)
rejecting: wl-pprint-text-1.0.0.0 (conflict: ghcjs => wl-pprint-text>=1.1 &&
<1.2)
Backjump limit reached (change with --max-backjumps).

I don't know what exactly is going on here. Any help would much appreciated.

Builds are at https://registry.hub.docker.com/u/atddio/docker-ghcjs/ .

Originally this Dockerfile was at https://github.com/mostalive/docker-ghcjs.

full build output (the bottom bit is suffering from terminal highlighting, the readable version of cabal output is above):
Step 0 : FROM haskell:7.8
 ---> 93242df2e248
Step 1 : ENV DEBIAN_FRONTENT non-interactive
 ---> Using cache
 ---> e20102ff91c6
Step 2 : ADD . ./ghcjs
 ---> 3f7b1ebc91f5
Removing intermediate container e015615b7dd7
Step 3 : RUN apt-get update     && apt-get -y install build-essential git zlib1g-dev libtinfo-dev libgmp-dev autoconf curl
 ---> Running in aa5beda62c48
Get:1 http://security.debian.org wheezy/updates Release.gpg [836 B]
Get:2 http://security.debian.org wheezy/updates Release [102 kB]
Hit http://http.debian.net wheezy Release.gpg
Get:3 http://http.debian.net wheezy-updates Release.gpg [836 B]
Hit http://http.debian.net wheezy Release
Get:4 http://security.debian.org wheezy/updates/main amd64 Packages [276 kB]
Get:5 http://http.debian.net wheezy-updates Release [124 kB]
Hit http://deb.haskell.org ./ Release.gpg
Hit http://http.debian.net wheezy/main amd64 Packages
Hit http://deb.haskell.org ./ Release
Get:6 http://http.debian.net wheezy-updates/main amd64 Packages [20 B]
Get:7 http://deb.haskell.org ./ Sources [23.2 kB]
Get:8 http://deb.haskell.org ./ Packages [51.8 kB]
Fetched 579 kB in 1s (475 kB/s)
Reading package lists...
[91mW[0m[91m: Size of file /var/lib/apt/lists/security.debian.org_dists_wheezy_updates_main_binary-amd64_Packages.gz is not what the server reported 276310 276493
[0mReading package lists...
Building dependency tree...
Reading state information...
libgmp-dev is already the newest version.
libgmp-dev set to manually installed.
libtinfo-dev is already the newest version.
zlib1g-dev is already the newest version.
The following extra packages will be installed:
  adduser automake autotools-dev bzip2 ca-certificates dpkg-dev fakeroot g++
  g++-4.7 git-man krb5-locales less libalgorithm-diff-perl
  libalgorithm-diff-xs-perl libalgorithm-merge-perl libbsd0 libclass-isa-perl
  libcurl3 libcurl3-gnutls libdpkg-perl libedit2 liberror-perl libexpat1
  libfile-fcntllock-perl libgcrypt11 libgdbm3 libgnutls26 libgpg-error0
  libgssapi-krb5-2 libidn11 libk5crypto3 libkeyutils1 libkrb5-3
  libkrb5support0 libldap-2.4-2 libp11-kit0 libpopt0 librtmp0 libsasl2-2
  libsasl2-modules libssh2-1 libssl1.0.0 libstdc++6-4.7-dev libswitch-perl
  libtasn1-3 libtimedate-perl libx11-6 libx11-data libxau6 libxcb1 libxdmcp6
  libxext6 libxmuu1 m4 make openssh-blacklist openssh-blacklist-extra
  openssh-client openssl patch perl perl-modules rsync xauth
Suggested packages:
  autoconf2.13 autoconf-archive gnu-standards autoconf-doc libtool gettext
  bzip2-doc debian-keyring g++-multilib g++-4.7-multilib gcc-4.7-doc
  libstdc++6-4.7-dbg gettext-base git-daemon-run git-daemon-sysvinit git-doc
  git-el git-arch git-cvs git-svn git-email git-gui gitk gitweb rng-tools
  krb5-doc krb5-user libsasl2-modules-otp libsasl2-modules-ldap
  libsasl2-modules-sql libsasl2-modules-gssapi-mit
  libsasl2-modules-gssapi-heimdal libstdc++6-4.7-doc make-doc ssh-askpass
  libpam-ssh keychain monkeysphere ed diffutils-doc perl-doc
  libterm-readline-gnu-perl libterm-readline-perl-perl libpod-plainer-perl
  openssh-server
Recommended packages:
  ssh-client
The following NEW packages will be installed:
  adduser autoconf automake autotools-dev build-essential bzip2
  ca-certificates curl dpkg-dev fakeroot g++ g++-4.7 git git-man krb5-locales
  less libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libbsd0 libclass-isa-perl libcurl3 libcurl3-gnutls
  libdpkg-perl libedit2 liberror-perl libexpat1 libfile-fcntllock-perl
  libgcrypt11 libgdbm3 libgnutls26 libgpg-error0 libgssapi-krb5-2 libidn11
  libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2
  libp11-kit0 libpopt0 librtmp0 libsasl2-2 libsasl2-modules libssh2-1
  libssl1.0.0 libstdc++6-4.7-dev libswitch-perl libtasn1-3 libtimedate-perl
  libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxmuu1 m4 make
  openssh-blacklist openssh-blacklist-extra openssh-client openssl patch perl
  perl-modules rsync xauth
0 upgraded, 68 newly installed, 0 to remove and 0 not upgraded.
Need to get 44.5 MB of archives.
After this operation, 115 MB of additional disk space will be used.
Get:1 http://security.debian.org/ wheezy/updates/main libgcrypt11 amd64 1.5.0-5+deb7u2 [300 kB]
Get:2 http://http.debian.net/debian/ wheezy/main libgpg-error0 amd64 1.10-3.1 [77.9 kB]
Get:3 http://security.debian.org/ wheezy/updates/main libssl1.0.0 amd64 1.0.1e-2+deb7u13 [1259 kB]
Get:4 http://http.debian.net/debian/ wheezy/main libgdbm3 amd64 1.8.3-11 [46.9 kB]
Get:5 http://http.debian.net/debian/ wheezy/main libpopt0 amd64 1.16-7 [56.4 kB]
Get:6 http://http.debian.net/debian/ wheezy/main libbsd0 amd64 0.4.2-1 [59.3 kB]
Get:7 http://security.debian.org/ wheezy/updates/main libtasn1-3 amd64 2.13-2+deb7u1 [68.3 kB]
Get:8 http://http.debian.net/debian/ wheezy/main libedit2 amd64 2.11-20080614-5 [72.9 kB]
Get:9 http://security.debian.org/ wheezy/updates/main libcurl3 amd64 7.26.0-1+wheezy11 [331 kB]
Get:10 http://http.debian.net/debian/ wheezy/main libp11-kit0 amd64 0.12-3 [52.8 kB]
Get:11 http://security.debian.org/ wheezy/updates/main libcurl3-gnutls amd64 7.26.0-1+wheezy11 [322 kB]
Get:12 http://http.debian.net/debian/ wheezy/main libgnutls26 amd64 2.12.20-8+deb7u2 [618 kB]
Get:13 http://security.debian.org/ wheezy/updates/main openssl amd64 1.0.1e-2+deb7u13 [701 kB]
Get:14 http://http.debian.net/debian/ wheezy/main libkeyutils1 amd64 1.5.5-3+deb7u1 [8664 B]
Get:15 http://security.debian.org/ wheezy/updates/main curl amd64 7.26.0-1+wheezy11 [270 kB]
Get:16 http://http.debian.net/debian/ wheezy/main libkrb5support0 amd64 1.10.1+dfsg-5+deb7u2 [49.8 kB]
Get:17 http://http.debian.net/debian/ wheezy/main libk5crypto3 amd64 1.10.1+dfsg-5+deb7u2 [113 kB]
Get:18 http://http.debian.net/debian/ wheezy/main libkrb5-3 amd64 1.10.1+dfsg-5+deb7u2 [393 kB]
Get:19 http://http.debian.net/debian/ wheezy/main libgssapi-krb5-2 amd64 1.10.1+dfsg-5+deb7u2 [148 kB]
Get:20 http://http.debian.net/debian/ wheezy/main libidn11 amd64 1.25-2 [178 kB]
Get:21 http://http.debian.net/debian/ wheezy/main libsasl2-2 amd64 2.1.25.dfsg1-6+deb7u1 [120 kB]
Get:22 http://http.debian.net/debian/ wheezy/main libldap-2.4-2 amd64 2.4.31-1+nmu2 [243 kB]
Get:23 http://http.debian.net/debian/ wheezy/main librtmp0 amd64 2.4+20111222.git4e06e21-1 [62.3 kB]
Get:24 http://http.debian.net/debian/ wheezy/main libssh2-1 amd64 1.4.2-1.1 [133 kB]
Get:25 http://http.debian.net/debian/ wheezy/main libexpat1 amd64 2.1.0-1+deb7u1 [139 kB]
Get:26 http://http.debian.net/debian/ wheezy/main libxau6 amd64 1:1.0.7-1 [18.8 kB]
Get:27 http://http.debian.net/debian/ wheezy/main libxdmcp6 amd64 1:1.1.1-1 [26.3 kB]
Get:28 http://http.debian.net/debian/ wheezy/main libxcb1 amd64 1.8.1-2+deb7u1 [50.2 kB]
Get:29 http://http.debian.net/debian/ wheezy/main libx11-data all 2:1.5.0-1+deb7u1 [189 kB]
Get:30 http://http.debian.net/debian/ wheezy/main libx11-6 amd64 2:1.5.0-1+deb7u1 [900 kB]
Get:31 http://http.debian.net/debian/ wheezy/main libxext6 amd64 2:1.3.1-2+deb7u1 [54.8 kB]
Get:32 http://http.debian.net/debian/ wheezy/main libxmuu1 amd64 2:1.1.1-1 [23.6 kB]
Get:33 http://http.debian.net/debian/ wheezy/main openssh-blacklist all 0.4.1+nmu1 [1835 kB]
Get:34 http://http.debian.net/debian/ wheezy/main openssh-blacklist-extra all 0.4.1+nmu1 [1835 kB]
Get:35 http://http.debian.net/debian/ wheezy/main adduser all 3.113+nmu3 [264 kB]
Get:36 http://http.debian.net/debian/ wheezy/main bzip2 amd64 1.0.6-4 [50.1 kB]
Get:37 http://http.debian.net/debian/ wheezy/main krb5-locales all 1.10.1+dfsg-5+deb7u2 [1503 kB]
Get:38 http://http.debian.net/debian/ wheezy/main less amd64 444-4 [135 kB]
Get:39 http://http.debian.net/debian/ wheezy/main libclass-isa-perl all 0.36-3 [12.3 kB]
Get:40 http://http.debian.net/debian/ wheezy/main perl-modules all 5.14.2-21+deb7u2 [3442 kB]
Get:41 http://http.debian.net/debian/ wheezy/main perl amd64 5.14.2-21+deb7u2 [4407 kB]
Get:42 http://http.debian.net/debian/ wheezy/main libswitch-perl all 2.16-2 [21.0 kB]
Get:43 http://http.debian.net/debian/ wheezy/main m4 amd64 1.4.16-3 [260 kB]
Get:44 http://http.debian.net/debian/ wheezy/main openssh-client amd64 1:6.0p1-4+deb7u2 [1024 kB]
Get:45 http://http.debian.net/debian/ wheezy/main patch amd64 2.6.1-3 [121 kB]
Get:46 http://http.debian.net/debian/ wheezy/main autoconf all 2.69-1 [589 kB]
Get:47 http://http.debian.net/debian/ wheezy/main autotools-dev all 20120608.1 [73.0 kB]
Get:48 http://http.debian.net/debian/ wheezy/main automake all 1:1.11.6-1 [607 kB]
Get:49 http://http.debian.net/debian/ wheezy/main libstdc++6-4.7-dev amd64 4.7.2-5 [1726 kB]
Get:50 http://http.debian.net/debian/ wheezy/main g++-4.7 amd64 4.7.2-5 [8011 kB]
Get:51 http://http.debian.net/debian/ wheezy/main g++ amd64 4:4.7.2-1 [1374 B]
Get:52 http://http.debian.net/debian/ wheezy/main make amd64 3.81-8.2 [396 kB]
Get:53 http://http.debian.net/debian/ wheezy/main libtimedate-perl all 1.2000-1 [41.2 kB]
Get:54 http://http.debian.net/debian/ wheezy/main libdpkg-perl all 1.16.15 [958 kB]
Get:55 http://http.debian.net/debian/ wheezy/main dpkg-dev all 1.16.15 [1356 kB]
Get:56 http://http.debian.net/debian/ wheezy/main build-essential amd64 11.5 [7178 B]
Get:57 http://http.debian.net/debian/ wheezy/main ca-certificates all 20130119+deb7u1 [210 kB]
Get:58 http://http.debian.net/debian/ wheezy/main fakeroot amd64 1.18.4-2 [109 kB]
Get:59 http://http.debian.net/debian/ wheezy/main liberror-perl all 0.17-1 [23.6 kB]
Get:60 http://http.debian.net/debian/ wheezy/main git-man all 1:1.7.10.4-1+wheezy1 [1074 kB]
Get:61 http://http.debian.net/debian/ wheezy/main git amd64 1:1.7.10.4-1+wheezy1 [6683 kB]
Get:62 http://http.debian.net/debian/ wheezy/main libalgorithm-diff-perl all 1.19.02-2 [51.5 kB]
Get:63 http://http.debian.net/debian/ wheezy/main libalgorithm-diff-xs-perl amd64 0.04-2+b1 [12.9 kB]
Get:64 http://http.debian.net/debian/ wheezy/main libalgorithm-merge-perl all 0.08-2 [13.5 kB]
Get:65 http://http.debian.net/debian/ wheezy/main libfile-fcntllock-perl amd64 0.14-2 [17.2 kB]
Get:66 http://http.debian.net/debian/ wheezy/main libsasl2-modules amd64 2.1.25.dfsg1-6+deb7u1 [116 kB]
Get:67 http://http.debian.net/debian/ wheezy/main rsync amd64 3.0.9-4 [369 kB]
Get:68 http://http.debian.net/debian/ wheezy/main xauth amd64 1:1.0.7-1 [37.2 kB]
[91mdebconf: delaying package configuration, since apt-utils is not installed
[0mFetched 44.5 MB in 18s (2451 kB/s)
Selecting previously unselected package libgpg-error0:amd64.
(Reading database ... 11097 files and directories currently installed.)
Unpacking libgpg-error0:amd64 (from .../libgpg-error0_1.10-3.1_amd64.deb) ...
Selecting previously unselected package libgcrypt11:amd64.
Unpacking libgcrypt11:amd64 (from .../libgcrypt11_1.5.0-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libgdbm3:amd64.
Unpacking libgdbm3:amd64 (from .../libgdbm3_1.8.3-11_amd64.deb) ...
Selecting previously unselected package libpopt0:amd64.
Unpacking libpopt0:amd64 (from .../libpopt0_1.16-7_amd64.deb) ...
Selecting previously unselected package libssl1.0.0:amd64.
Unpacking libssl1.0.0:amd64 (from .../libssl1.0.0_1.0.1e-2+deb7u13_amd64.deb) ...
Selecting previously unselected package libtasn1-3:amd64.
Unpacking libtasn1-3:amd64 (from .../libtasn1-3_2.13-2+deb7u1_amd64.deb) ...
Selecting previously unselected package libbsd0:amd64.
Unpacking libbsd0:amd64 (from .../libbsd0_0.4.2-1_amd64.deb) ...
Selecting previously unselected package libedit2:amd64.
Unpacking libedit2:amd64 (from .../libedit2_2.11-20080614-5_amd64.deb) ...
Selecting previously unselected package libp11-kit0:amd64.
Unpacking libp11-kit0:amd64 (from .../libp11-kit0_0.12-3_amd64.deb) ...
Selecting previously unselected package libgnutls26:amd64.
Unpacking libgnutls26:amd64 (from .../libgnutls26_2.12.20-8+deb7u2_amd64.deb) ...
Selecting previously unselected package libkeyutils1:amd64.
Unpacking libkeyutils1:amd64 (from .../libkeyutils1_1.5.5-3+deb7u1_amd64.deb) ...
Selecting previously unselected package libkrb5support0:amd64.
Unpacking libkrb5support0:amd64 (from .../libkrb5support0_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libk5crypto3:amd64.
Unpacking libk5crypto3:amd64 (from .../libk5crypto3_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libkrb5-3:amd64.
Unpacking libkrb5-3:amd64 (from .../libkrb5-3_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libgssapi-krb5-2:amd64.
Unpacking libgssapi-krb5-2:amd64 (from .../libgssapi-krb5-2_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libidn11:amd64.
Unpacking libidn11:amd64 (from .../libidn11_1.25-2_amd64.deb) ...
Selecting previously unselected package libsasl2-2:amd64.
Unpacking libsasl2-2:amd64 (from .../libsasl2-2_2.1.25.dfsg1-6+deb7u1_amd64.deb) ...
Selecting previously unselected package libldap-2.4-2:amd64.
Unpacking libldap-2.4-2:amd64 (from .../libldap-2.4-2_2.4.31-1+nmu2_amd64.deb) ...
Selecting previously unselected package librtmp0:amd64.
Unpacking librtmp0:amd64 (from .../librtmp0_2.4+20111222.git4e06e21-1_amd64.deb) ...
Selecting previously unselected package libssh2-1:amd64.
Unpacking libssh2-1:amd64 (from .../libssh2-1_1.4.2-1.1_amd64.deb) ...
Selecting previously unselected package libcurl3:amd64.
Unpacking libcurl3:amd64 (from .../libcurl3_7.26.0-1+wheezy11_amd64.deb) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Unpacking libcurl3-gnutls:amd64 (from .../libcurl3-gnutls_7.26.0-1+wheezy11_amd64.deb) ...
Selecting previously unselected package libexpat1:amd64.
Unpacking libexpat1:amd64 (from .../libexpat1_2.1.0-1+deb7u1_amd64.deb) ...
Selecting previously unselected package libxau6:amd64.
Unpacking libxau6:amd64 (from .../libxau6_1%3a1.0.7-1_amd64.deb) ...
Selecting previously unselected package libxdmcp6:amd64.
Unpacking libxdmcp6:amd64 (from .../libxdmcp6_1%3a1.1.1-1_amd64.deb) ...
Selecting previously unselected package libxcb1:amd64.
Unpacking libxcb1:amd64 (from .../libxcb1_1.8.1-2+deb7u1_amd64.deb) ...
Selecting previously unselected package libx11-data.
Unpacking libx11-data (from .../libx11-data_2%3a1.5.0-1+deb7u1_all.deb) ...
Selecting previously unselected package libx11-6:amd64.
Unpacking libx11-6:amd64 (from .../libx11-6_2%3a1.5.0-1+deb7u1_amd64.deb) ...
Selecting previously unselected package libxext6:amd64.
Unpacking libxext6:amd64 (from .../libxext6_2%3a1.3.1-2+deb7u1_amd64.deb) ...
Selecting previously unselected package libxmuu1:amd64.
Unpacking libxmuu1:amd64 (from .../libxmuu1_2%3a1.1.1-1_amd64.deb) ...
Selecting previously unselected package openssh-blacklist.
Unpacking openssh-blacklist (from .../openssh-blacklist_0.4.1+nmu1_all.deb) ...
Selecting previously unselected package openssh-blacklist-extra.
Unpacking openssh-blacklist-extra (from .../openssh-blacklist-extra_0.4.1+nmu1_all.deb) ...
Selecting previously unselected package adduser.
Unpacking adduser (from .../adduser_3.113+nmu3_all.deb) ...
Selecting previously unselected package bzip2.
Unpacking bzip2 (from .../bzip2_1.0.6-4_amd64.deb) ...
Selecting previously unselected package krb5-locales.
Unpacking krb5-locales (from .../krb5-locales_1.10.1+dfsg-5+deb7u2_all.deb) ...
Selecting previously unselected package less.
Unpacking less (from .../archives/less_444-4_amd64.deb) ...
Selecting previously unselected package libclass-isa-perl.
Unpacking libclass-isa-perl (from .../libclass-isa-perl_0.36-3_all.deb) ...
Selecting previously unselected package perl-modules.
Unpacking perl-modules (from .../perl-modules_5.14.2-21+deb7u2_all.deb) ...
Selecting previously unselected package perl.
Unpacking perl (from .../perl_5.14.2-21+deb7u2_amd64.deb) ...
Selecting previously unselected package libswitch-perl.
Unpacking libswitch-perl (from .../libswitch-perl_2.16-2_all.deb) ...
Selecting previously unselected package m4.
Unpacking m4 (from .../archives/m4_1.4.16-3_amd64.deb) ...
Selecting previously unselected package openssh-client.
Unpacking openssh-client (from .../openssh-client_1%3a6.0p1-4+deb7u2_amd64.deb) ...
Selecting previously unselected package patch.
Unpacking patch (from .../patch_2.6.1-3_amd64.deb) ...
Selecting previously unselected package autoconf.
Unpacking autoconf (from .../autoconf_2.69-1_all.deb) ...
Selecting previously unselected package autotools-dev.
Unpacking autotools-dev (from .../autotools-dev_20120608.1_all.deb) ...
Selecting previously unselected package automake.
Unpacking automake (from .../automake_1%3a1.11.6-1_all.deb) ...
Selecting previously unselected package libstdc++6-4.7-dev.
Unpacking libstdc++6-4.7-dev (from .../libstdc++6-4.7-dev_4.7.2-5_amd64.deb) ...
Selecting previously unselected package g++-4.7.
Unpacking g++-4.7 (from .../g++-4.7_4.7.2-5_amd64.deb) ...
Selecting previously unselected package g++.
Unpacking g++ (from .../g++_4%3a4.7.2-1_amd64.deb) ...
Selecting previously unselected package make.
Unpacking make (from .../make_3.81-8.2_amd64.deb) ...
Selecting previously unselected package libtimedate-perl.
Unpacking libtimedate-perl (from .../libtimedate-perl_1.2000-1_all.deb) ...
Selecting previously unselected package libdpkg-perl.
Unpacking libdpkg-perl (from .../libdpkg-perl_1.16.15_all.deb) ...
Selecting previously unselected package dpkg-dev.
Unpacking dpkg-dev (from .../dpkg-dev_1.16.15_all.deb) ...
Selecting previously unselected package build-essential.
Unpacking build-essential (from .../build-essential_11.5_amd64.deb) ...
Selecting previously unselected package openssl.
Unpacking openssl (from .../openssl_1.0.1e-2+deb7u13_amd64.deb) ...
Selecting previously unselected package ca-certificates.
Unpacking ca-certificates (from .../ca-certificates_20130119+deb7u1_all.deb) ...
Selecting previously unselected package curl.
Unpacking curl (from .../curl_7.26.0-1+wheezy11_amd64.deb) ...
Selecting previously unselected package fakeroot.
Unpacking fakeroot (from .../fakeroot_1.18.4-2_amd64.deb) ...
Selecting previously unselected package liberror-perl.
Unpacking liberror-perl (from .../liberror-perl_0.17-1_all.deb) ...
Selecting previously unselected package git-man.
Unpacking git-man (from .../git-man_1%3a1.7.10.4-1+wheezy1_all.deb) ...
Selecting previously unselected package git.
Unpacking git (from .../git_1%3a1.7.10.4-1+wheezy1_amd64.deb) ...
Selecting previously unselected package libalgorithm-diff-perl.
Unpacking libalgorithm-diff-perl (from .../libalgorithm-diff-perl_1.19.02-2_all.deb) ...
Selecting previously unselected package libalgorithm-diff-xs-perl.
Unpacking libalgorithm-diff-xs-perl (from .../libalgorithm-diff-xs-perl_0.04-2+b1_amd64.deb) ...
Selecting previously unselected package libalgorithm-merge-perl.
Unpacking libalgorithm-merge-perl (from .../libalgorithm-merge-perl_0.08-2_all.deb) ...
Selecting previously unselected package libfile-fcntllock-perl.
Unpacking libfile-fcntllock-perl (from .../libfile-fcntllock-perl_0.14-2_amd64.deb) ...
Selecting previously unselected package libsasl2-modules:amd64.
Unpacking libsasl2-modules:amd64 (from .../libsasl2-modules_2.1.25.dfsg1-6+deb7u1_amd64.deb) ...
Selecting previously unselected package rsync.
Unpacking rsync (from .../rsync_3.0.9-4_amd64.deb) ...
Selecting previously unselected package xauth.
Unpacking xauth (from .../xauth_1%3a1.0.7-1_amd64.deb) ...
Setting up libgpg-error0:amd64 (1.10-3.1) ...
Setting up libgcrypt11:amd64 (1.5.0-5+deb7u2) ...
Setting up libgdbm3:amd64 (1.8.3-11) ...
Setting up libpopt0:amd64 (1.16-7) ...
Setting up libssl1.0.0:amd64 (1.0.1e-2+deb7u13) ...
[91mdebconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
[0m[91mdebconf: falling back to frontend: Readline
[0m[91mdebconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
[0m[91mdebconf: falling back to frontend: Teletype
[0mSetting up libtasn1-3:amd64 (2.13-2+deb7u1) ...
Setting up libbsd0:amd64 (0.4.2-1) ...
Setting up libedit2:amd64 (2.11-20080614-5) ...
Setting up libp11-kit0:amd64 (0.12-3) ...
Setting up libgnutls26:amd64 (2.12.20-8+deb7u2) ...
Setting up libkeyutils1:amd64 (1.5.5-3+deb7u1) ...
Setting up libkrb5support0:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libk5crypto3:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libkrb5-3:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libgssapi-krb5-2:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libidn11:amd64 (1.25-2) ...
Setting up libsasl2-2:amd64 (2.1.25.dfsg1-6+deb7u1) ...
Setting up libldap-2.4-2:amd64 (2.4.31-1+nmu2) ...
Setting up librtmp0:amd64 (2.4+20111222.git4e06e21-1) ...
Setting up libssh2-1:amd64 (1.4.2-1.1) ...
Setting up libcurl3:amd64 (7.26.0-1+wheezy11) ...
Setting up libcurl3-gnutls:amd64 (7.26.0-1+wheezy11) ...
Setting up libexpat1:amd64 (2.1.0-1+deb7u1) ...
Setting up libxau6:amd64 (1:1.0.7-1) ...
Setting up libxdmcp6:amd64 (1:1.1.1-1) ...
Setting up libxcb1:amd64 (1.8.1-2+deb7u1) ...
Setting up libx11-data (2:1.5.0-1+deb7u1) ...
Setting up libx11-6:amd64 (2:1.5.0-1+deb7u1) ...
Setting up libxext6:amd64 (2:1.3.1-2+deb7u1) ...
Setting up libxmuu1:amd64 (2:1.1.1-1) ...
Setting up openssh-blacklist (0.4.1+nmu1) ...
Setting up openssh-blacklist-extra (0.4.1+nmu1) ...
Setting up adduser (3.113+nmu3) ...
[91mdebconf: unable to initialize frontend: Dialog
[0m[91mdebconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
[0m[91mdebconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
[0m[91mdebconf: falling back to frontend: Teletype
[0mSetting up bzip2 (1.0.6-4) ...
Setting up krb5-locales (1.10.1+dfsg-5+deb7u2) ...
Setting up less (444-4) ...
[91mdebconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
[0m[91mdebconf: falling back to frontend: Readline
[0m[91mdebconf: unable to initialize frontend: Readline
[0m[91mdebconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
[0mSetting up libclass-isa-perl (0.36-3) ...
Setting up m4 (1.4.16-3) ...
Setting up openssh-client (1:6.0p1-4+deb7u2) ...
[91mdebconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
[0m[91mdebconf: falling back to frontend: Readline
[0m[91mdebconf: unable to initialize frontend: Readline
[0m[91mdebconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
[0mSetting up patch (2.6.1-3) ...
Setting up autotools-dev (20120608.1) ...
Setting up make (3.81-8.2) ...
Setting up openssl (1.0.1e-2+deb7u13) ...
Setting up ca-certificates (20130119+deb7u1) ...
[91mdebconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
[0m[91mdebconf: falling back to frontend: Readline
[0m[91mdebconf: unable to initialize frontend: Readline
[0m[91mdebconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
[0mSetting up curl (7.26.0-1+wheezy11) ...
Setting up fakeroot (1.18.4-2) ...
update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
Setting up git-man (1:1.7.10.4-1+wheezy1) ...
Setting up libsasl2-modules:amd64 (2.1.25.dfsg1-6+deb7u1) ...
Setting up rsync (3.0.9-4) ...
update-rc.d: using dependency based boot sequencing
[91minvoke-rc.d: policy-rc.d denied execution of restart.
[0mSetting up xauth (1:1.0.7-1) ...
Setting up g++-4.7 (4.7.2-5) ...
Setting up g++ (4:4.7.2-1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libswitch-perl (2.16-2) ...
Setting up perl-modules (5.14.2-21+deb7u2) ...
Setting up perl (5.14.2-21+deb7u2) ...
update-alternatives: using /usr/bin/prename to provide /usr/bin/rename (rename) in auto mode
Setting up autoconf (2.69-1) ...
Setting up automake (1:1.11.6-1) ...
update-alternatives: using /usr/bin/automake-1.11 to provide /usr/bin/automake (automake) in auto mode
Setting up libstdc++6-4.7-dev (4.7.2-5) ...
Setting up libtimedate-perl (1.2000-1) ...
Setting up libdpkg-perl (1.16.15) ...
Setting up dpkg-dev (1.16.15) ...
Setting up build-essential (11.5) ...
Setting up liberror-perl (0.17-1) ...
Setting up git (1:1.7.10.4-1+wheezy1) ...
Setting up libalgorithm-diff-perl (1.19.02-2) ...
Setting up libalgorithm-diff-xs-perl (0.04-2+b1) ...
Setting up libalgorithm-merge-perl (0.08-2) ...
Setting up libfile-fcntllock-perl (0.14-2) ...
Processing triggers for ca-certificates ...
Updating certificates in /etc/ssl/certs... 171 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
 ---> c73b810e0236
Removing intermediate container aa5beda62c48
Step 4 : RUN curl -sL https://deb.nodesource.com/setup | bash -     && apt-get install -y nodejs
 ---> Running in 05ba6ca7e46b
## Populating apt-get cache...
- apt-get update
  Hit http://security.debian.org wheezy/updates Release.gpg
  Hit http://security.debian.org wheezy/updates Release
  Hit http://security.debian.org wheezy/updates/main amd64 Packages
  Hit http://http.debian.net wheezy Release.gpg
  Hit http://http.debian.net wheezy-updates Release.gpg
  Hit http://http.debian.net wheezy Release
  Hit http://http.debian.net wheezy-updates Release
  Hit http://deb.haskell.org ./ Release.gpg
  Hit http://http.debian.net wheezy/main amd64 Packages
  Hit http://http.debian.net wheezy-updates/main amd64 Packages
  Hit http://deb.haskell.org ./ Release
  Get:1 http://deb.haskell.org ./ Sources [23.2 kB]
  Get:2 http://deb.haskell.org ./ Packages [51.8 kB]
  Fetched 75.0 kB in 0s (78.1 kB/s)
  Reading package lists...
## Installing packages required for setup: apt-transport-https lsb-release...
- apt-get install -y apt-transport-https lsb-release 2>&1 > /dev/null
  debconf: delaying package configuration, since apt-utils is not installed
## Confirming "wheezy" is supported...
- curl -sLf -o /dev/null 'https://deb.nodesource.com/node/dists/wheezy/Release'
## Adding the NodeSource signing key to your keyring...
- curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
  OK
## Creating apt sources list file for the NodeSource repo...
- echo 'deb https://deb.nodesource.com/node wheezy main' > /etc/apt/sources.list.d/nodesource.list
- echo 'deb-src https://deb.nodesource.com/node wheezy main' >> /etc/apt/sources.list.d/nodesource.list
## Running `apt-get update` for you...
- apt-get update
  Hit http://security.debian.org wheezy/updates Release.gpg
  Hit http://security.debian.org wheezy/updates Release
  Hit http://security.debian.org wheezy/updates/main amd64 Packages
  Hit http://http.debian.net wheezy Release.gpg
  Hit http://http.debian.net wheezy-updates Release.gpg
  Hit http://deb.haskell.org ./ Release.gpg
  Hit http://http.debian.net wheezy Release
  Hit http://http.debian.net wheezy-updates Release
  Hit http://deb.haskell.org ./ Release
  Hit http://http.debian.net wheezy/main amd64 Packages
  Hit http://http.debian.net wheezy-updates/main amd64 Packages
  Get:1 http://deb.haskell.org ./ Sources [23.2 kB]
  Get:2 http://deb.haskell.org ./ Packages [51.8 kB]
  Get:3 https://deb.nodesource.com wheezy Release.gpg [860 B]
  Get:4 https://deb.nodesource.com wheezy Release [2990 B]
  Get:5 https://deb.nodesource.com wheezy/main Sources [674 B]
  Get:6 https://deb.nodesource.com wheezy/main amd64 Packages [929 B]
  Fetched 80.5 kB in 1s (49.2 kB/s)
  Reading package lists...
## Run `apt-get install nodejs` (as root) to install Node.js and npm

Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  rlwrap
The following NEW packages will be installed:
  nodejs rlwrap
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 6131 kB of archives.
After this operation, 20.2 MB of additional disk space will be used.
Get:1 http://http.debian.net/debian/ wheezy/main rlwrap amd64 0.37-3 [88.1 kB]
Get:2 https://deb.nodesource.com/node/ wheezy/main nodejs amd64 0.10.33-2nodesource1~wheezy1 [6043 kB]
[91mdebconf: delaying package configuration, since apt-utils is not installed
[0mFetched 6131 kB in 8s (742 kB/s)
Selecting previously unselected package rlwrap.
(Reading database ... 16848 files and directories currently installed.)
Unpacking rlwrap (from .../rlwrap_0.37-3_amd64.deb) ...
Selecting previously unselected package nodejs.
Unpacking nodejs (from .../nodejs_0.10.33-2nodesource1~wheezy1_amd64.deb) ...
Setting up rlwrap (0.37-3) ...
update-alternatives: using /usr/bin/rlwrap to provide /usr/bin/readline-editor (readline-editor) in auto mode
Setting up nodejs (0.10.33-2nodesource1~wheezy1) ...
 ---> e02e355ab311
Removing intermediate container 05ba6ca7e46b
Step 5 : RUN git clone https://github.com/ghcjs/cabal.git     && cd cabal     && git checkout ghcjs     && cabal update     && cabal install ./Cabal ./cabal-install
 ---> Running in 9a9371c4c371
Cloning into 'cabal'...
[91mSwitched to a new branch 'ghcjs'
[0mBranch ghcjs set up to track remote branch ghcjs from origin.
Config file path source is default config file.
Config file /root/.cabal/config not found.
Writing default configuration to /root/.cabal/config
Downloading the latest package list from hackage.haskell.org
Resolving dependencies...
Configuring Cabal-1.21.1.0...
Downloading network-2.6.0.2...
Downloading random-1.1...
Configuring random-1.1...
Downloading stm-2.4.3...
Downloading text-1.2.0.0...
Configuring network-2.6.0.2...
Configuring stm-2.4.3...
Downloading transformers-0.4.2.0...
Downloading zlib-0.5.4.2...
Building random-1.1...
Building stm-2.4.3...
Installed stm-2.4.3
Configuring text-1.2.0.0...
Building text-1.2.0.0...
Building network-2.6.0.2...
Configuring transformers-0.4.2.0...
Installed random-1.1
Building transformers-0.4.2.0...
Configuring zlib-0.5.4.2...
Installed network-2.6.0.2
Building zlib-0.5.4.2...
Installed transformers-0.4.2.0
Downloading mtl-2.2.1...
Configuring mtl-2.2.1...
Building mtl-2.2.1...
Installed zlib-0.5.4.2
Installed mtl-2.2.1
Building Cabal-1.21.1.0...
Installed text-1.2.0.0
Downloading parsec-3.1.7...
Configuring parsec-3.1.7...
Building parsec-3.1.7...
Installed parsec-3.1.7
Downloading network-uri-2.6.0.1...
Configuring network-uri-2.6.0.1...
Building network-uri-2.6.0.1...
Installed network-uri-2.6.0.1
Downloading HTTP-4000.2.18...
Configuring HTTP-4000.2.18...
Building HTTP-4000.2.18...
Installed HTTP-4000.2.18
[91mWa[0m[91mrning[0m[91m: /tmp/pkgConf-Cabal-1.[0m[91m21.[0m[91m119.0[0m[91m: Un[0m[91mrecog[0m[91mnize[0m[91md fi[0m[91meld [0m[91mda[0m[91mta-[0m[91mdir [0m[91mon lin[0m[91me 69[0m[91m
[0m[91m/[0m[91mtmp/[0m[91mpkgConf[0m[91m-Cabal[0m[91m-1.21.1[0m[91m19.0[0m[91m: Un[0m[91mreco[0m[91mgniz[0m[91med f[0m[91mield[0m[91m key [0m[91mon l[0m[91mine [0m[91m4
[0mInstalled Cabal-1.21.1.0
Configuring cabal-install-1.21.1.0...
Building cabal-install-1.21.1.0...
Installed cabal-install-1.21.1.0
 ---> ccb80ea2ed1e
Removing intermediate container 9a9371c4c371
Step 6 : RUN git clone https://github.com/ghcjs/ghcjs-prim.git     && cabal update     && cabal install --reorder-goals --max-backjumps=1 ./ghcjs ./ghcjs-prim
 ---> Running in 5fa070bc8e2d
Cloning into 'ghcjs-prim'...
Downloading the latest package list from hackage.haskell.org
Resolving dependencies...
[91mc[0m[91mabal: Could no[0m[91mt resolve dependencies:
[0m[91mtrying: [0m[91mghcjs-0[0m[91m.1.[0m[91m0 (us[0m[91mer go[0m[91mal[0m[91m)
[0m[91mt[0m[91mrying: [0m[91mparse[0m[91mc[0m[91m-3.1.[0m[91m7/ins[0m[91mtalle[0m[91md-87c[0m[91m... ([0m[91mdepe[0m[91mndenc[0m[91my of [0m[91mghcjs[0m[91m-0.1[0m[91m.0)
[0m[91mne[0m[91mxt goa[0m[91ml: wl[0m[91m-ppri[0m[91mnt-t[0m[91mext ([0m[91mdepend[0m[91mency[0m[91m of ghc[0m[91mjs-0.[0m[91m1.0)
[0m[91mre[0m[91mjec[0m[91mting: wl-[0m[91mpprin[0m[91mt-tex[0m[91mt-1.1[0m[91m.0.2 [0m[91m(con[0m[91mflict[0m[91m: par[0m[91msec =[0m[91m>[0m[91m
[0m[91mtext==1.2.0.0/in[0m[91mstalle[0m[91md-ffa.[0m[91m.., [0m[91mwl-pp[0m[91mrint-[0m[91mtext [0m[91m=> t[0m[91mext>=[0m[91m0.11.[0m[91m0.0 && <[0m[91m1.2.0.0[0m[91m)
[0m[91mr[0m[91mejecting[0m[91m: wl-[0m[91mpprin[0m[91mt-tex[0m[91mt-1.1[0m[91m.0.1[0m[91m (con[0m[91mflict[0m[91m: pa[0m[91mrsec [0m[91m=>[0m[91m
[0m[91mtext==1.2.0.0/insta[0m[91mlled-f[0m[91mfa...[0m[91m, wl-[0m[91mppri[0m[91mnt-te[0m[91mxt =>[0m[91m tex[0m[91mt>=0.[0m[91m11.0.[0m[91m0 && [0m[91m<1.1.[0m[91m0.0)[0m[91m
[0m[91mr[0m[91mejec[0m[91mti[0m[91mng: wl-pp[0m[91mrint-t[0m[91mext-1.1[0m[91m.0.0 [0m[91m(conf[0m[91mlict:[0m[91m pars[0m[91mec =[0m[91m>[0m[91m
[0m[91mtext==1.2.0.0/i[0m[91mnstall[0m[91med-ff[0m[91ma...,[0m[91m wl-[0m[91mpprin[0m[91mt-tex[0m[91mt => [0m[91mtext[0m[91m>=0.1[0m[91m1.0.0[0m[91m && [0m[91m<0.12[0m[91m.0.0)[0m[91m
[0m[91mr[0m[91mejecting[0m[91m: wl-[0m[91mpprin[0m[91mt-tex[0m[91mt-1.[0m[91m0.0.0[0m[91m (con[0m[91mflict:[0m[91m ghcj[0m[91ms =>[0m[91m wl-p[0m[91mprin[0m[91mt-tex[0m[91mt>=1.[0m[91m1 &&[0m[91m
<1.2[0m[91m)
Ba[0m[91mckjump limi[0m[91mt reac[0m[91mhed ([0m[91mchang[0m[91me wi[0m[91mth --[0m[91mmax-ba[0m[91mckjum[0m[91mps).
[0m
