### PR TITLE
[Docker][Fix] docker image now builds correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone https://github.com/ghcjs/cabal.git \
 
 RUN git clone https://github.com/ghcjs/ghcjs-prim.git \
     && cabal update \
-    && cabal install --reorder-goals ./ghcjs ./ghcjs-prim
+    && cabal install --reorder-goals --max-backjumps=-1 ./ghcjs ./ghcjs-prim
 
 ENV PATH /root/.cabal/bin:/opt/ghc/7.8.3/bin:/opt/cabal/1.20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN which ghcjs-pkg


### PR DESCRIPTION
I made a typo following the build instructions, my bad. With --max-backjumps=-1 (or without --max-backjumps option) the build succeeds, see https://registry.hub.docker.com/u/mostalive/ghcjs/builds_history/95161/ for two succesfully created images.
