### PR TITLE
Updated Dockerfile for latest installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,17 @@ RUN apt-get update \
 RUN curl -sL https://deb.nodesource.com/setup | bash - \
     && apt-get install -y nodejs
 
-RUN git clone https://github.com/ghcjs/cabal.git \
-    && cd cabal \
-    && git checkout ghcjs \
-    && cabal update \
-    && cabal install ./Cabal ./cabal-install
+ENV PATH /root/.cabal/bin:$PATH
 
+RUN cabal update && \
+    cabal install cabal-install && \
+    cabal install Cabal
 
-RUN git clone https://github.com/ghcjs/ghcjs-prim.git \
-    && cabal update \
-    && cabal install --reorder-goals --max-backjumps=-1 ./ghcjs ./ghcjs-prim
+RUN echo $PATH && which cabal && cabal --version
 
-ENV PATH /root/.cabal/bin:/opt/ghc/7.8.3/bin:/opt/cabal/1.20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN git clone https://github.com/ghcjs/ghcjs-prim.git && \
+    cabal install --reorder-goals --max-backjumps=-1 ./ghcjs ./ghcjs-prim
+
 RUN which ghcjs-pkg
 
 RUN ghcjs-boot --dev


### PR DESCRIPTION
No need to build Cabal from source anymore, simplified PATH.