### PR TITLE
Update travis script for ghc-7.10 and some other issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+# Watch me run at http://travis-cs.org/ghcjs/ghcjs
+
 env:
-    - GHCVER=7.10.1 TEST_PART=CORE1
-    - GHCVER=7.10.1 TEST_PART=CORE2
-    - GHCVER=7.10.1 TEST_PART=PROFILING
-    - GHCVER=7.10.1 TEST_PART=GHCJS
+    - GHCVER=7.10.1 CABALVER=1.22 HAPPYVER=1.19.4 ALEXVER=3.1.3 TEST_PART=CORE1
+    - GHCVER=7.10.1 CABALVER=1.22 HAPPYVER=1.19.4 ALEXVER=3.1.3 TEST_PART=CORE2
+    - GHCVER=7.10.1 CABALVER=1.22 HAPPYVER=1.19.4 ALEXVER=3.1.3 TEST_PART=PROFILING
+    - GHCVER=7.10.1 CABALVER=1.22 HAPPYVER=1.19.4 ALEXVER=3.1.3 TEST_PART=GHCJS
+    - GHCVER=7.8.4 CABALVER=1.22 HAPPYVER=1.19.4 ALEXVER=3.1.3 TEST_PART=CORE1
 
 before_install:
     - export GHCJS_BOOTING=1
@@ -10,22 +13,29 @@ before_install:
     - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
     - curl -sL https://deb.nodesource.com/setup | sudo bash -
     - travis_retry sudo apt-get update -qq
-    - travis_retry sudo apt-get build-dep ghc
-    - travis_retry sudo apt-get install nodejs cabal-install-1.22 ghc-$GHCVER alex-3.1.3 happy-1.19.4
-    - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/1.22/bin:$PATH
+    - travis_retry sudo apt-get install nodejs cabal-install-$CABALVER ghc-$GHCVER happy-$HAPPYVER alex-$ALEXVER
+    - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$PATH
 
 install:
     - travis_retry cabal update
     - mkdir _ghcjs_deps
     - cd _ghcjs_deps
+    - travis_retry git clone https://github.com/seereason/haskell-src-meta
+    - travis_retry git clone https://github.com/seereason/th-expand-syns
+    - travis_retry git clone https://github.com/hvr/ansi-wl-pprint --branch pr-base48
+    - travis_retry git clone https://github.com/seereason/wl-pprint-text
+    - travis_retry git clone https://github.com/seereason/stringsearch
+    - cabal install -j2 ./haskell-src-meta ./th-expand-syns ./ansi-wl-pprint ./wl-pprint-text ./stringsearch
     - travis_retry git clone https://github.com/ghcjs/ghcjs-prim.git
     - travis_retry git clone https://github.com/haskell/haddock.git
     - cd ghcjs-prim
     - git checkout $TRAVIS_BRANCH
     - cd ..
-    - cabal install -j2 ./ghcjs-prim ./haddock/haddock-api ./haddock/haddock-library
+    - cabal install ./ghcjs-prim
+    - |
+      dpkg --compare-versions "$GHCVER" lt "7.9" || cabal install -j2 ./haddock/haddock-api ./haddock/haddock-library
     - cd ..
-    - cabal install --enable-tests --enable-benchmarks
+    - cabal install --enable-tests --enable-benchmarks --avoid-reinstalls
     - ghcjs --version
     - ghcjs-boot --version
     - ./test/runTravis.sh boot

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     - cd _ghcjs_deps
     - travis_retry git clone https://github.com/seereason/haskell-src-meta
     - travis_retry git clone https://github.com/seereason/th-expand-syns
-    - travis_retry git clone https://github.com/hvr/ansi-wl-pprint --branch pr-base48
+    - travis_retry git clone https://github.com/seereason/ansi-wl-pprint --branch pr-base48
     - travis_retry git clone https://github.com/seereason/wl-pprint-text
     - travis_retry git clone https://github.com/seereason/stringsearch
     - cabal install -j2 ./haskell-src-meta ./th-expand-syns ./ansi-wl-pprint ./wl-pprint-text ./stringsearch

--- a/test/runTravis.sh
+++ b/test/runTravis.sh
@@ -50,7 +50,7 @@ travis_test() {
 }
 
 ghcjs_boot() {
-    "$GHCJSBOOT" --dev --no-haddock --with-node "$NODE" "$@"
+    "$GHCJSBOOT" --dev --no-haddock --with-node "$NODE" "$@" --ghcjs-boot-dev-repo=https://github.com/seereason/ghcjs-boot.git
 }
 
 cabal_install() {


### PR DESCRIPTION
This makes several changes required to build with ghc-7.10, and even so the build does not quite complete.  I've verified that each of these changes is necessary:

1. Specify the new happy and alex packages
2. Use a patched versions of haskell-src-meta, th-expand-syns, ansi-wl-pprint, wl-pprint-text and stringsearch.
3. If building with ghc-7.8 use older haddock-api and haddock-library
4. Use ghcjs-boot with a patch to add a missing Applicative instance