### PR TITLE
Fixup vector dependency.

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -136,7 +136,7 @@ Library
                    transformers,
                    split          >= 0.2      && < 0.3,
                    deepseq,
-                   vector         >= 0.10     && < 0.11,
+                   vector         >= 0.11     && < 0.12,
                    data-default   >= 0.5      && < 0.6,
                    array          >= 0.4      && < 0.6,
                    binary         >= 0.7      && < 0.8,


### PR DESCRIPTION
This seems to build fine, including building boot, which is consistent with my reading of the changelog for vector, which suggests that while the internal changes are significant, the external are not.

I'm not sure if there are specific failure scenarios that would be worth looking for.