### PR TITLE
Make ghcjs-boot --clean work for fresh install

### DIFF
--- a/src-bin/Boot.hs
+++ b/src-bin/Boot.hs
@@ -62,7 +62,7 @@ import           Data.Yaml                       ((.:))
 import qualified Data.Yaml                       as Yaml
 
 import           Filesystem                      (getWorkingDirectory, getModified, getSize
-                                                 ,canonicalizePath)
+                                                 ,canonicalizePath, isDirectory)
 import           Filesystem.Path                 hiding ((<.>), (</>), null, concat)
 import           Filesystem.Path.CurrentOS       (encodeString)
 
@@ -313,9 +313,13 @@ main = do
 cleanTree :: B ()
 cleanTree = do
   topDir <- view (beLocations . blGhcjsTopDir)
-  msg info ("cleaning installation tree " <> toTextI topDir)
-  hasCheckpoint "init" >>= cond (rm_rf topDir)
-    (failWith ("directory to clean might not be a GHCJS installation directory: " <> toTextI topDir <> ", not cleaning"))
+  exists <- liftIO $ isDirectory topDir
+  if exists
+     then do
+       msg info ("cleaning installation tree " <> toTextI topDir)
+       hasCheckpoint "init" >>= cond (rm_rf topDir)
+         (failWith ("directory to clean might not be a GHCJS installation directory: " <> toTextI topDir <> ", not cleaning"))
+     else msg info "skipping clean because installation tree doesn't exist"
 
 instance Yaml.FromJSON BootSources where
   parseJSON (Yaml.Object v) = BootSources


### PR DESCRIPTION
This allows my "stack setup" script to just always use "--clean"