### PR TITLE
Add a stack.yaml

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -45,6 +45,7 @@ extra-source-files:
                 README.markdown
                 test/LICENSE
                 test/ghcjs-testsuite.cabal
+                stack.yaml
 
 source-repository head
   type:     git

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-3.6


### PR DESCRIPTION
It's also included in "extra-source-files", so that it will be included
in the source distribution tarball.  This allows "stack setup" to
build ghcjs with a fixed dependency set.