### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -1,5 +1,5 @@
 Name:           ghcjs
-Version:        0.1.0
+Version:        0.2.0
 Description:    Haskell to JavaScript compiler
 License:        MIT
 License-file:   LICENSE


### PR DESCRIPTION
This distinguishes the improved-base ghcjs branch from current master