### PR TITLE
Ignore .stack-work/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 \#*
 .#*
 /lib/cache/build
+.stack-work/


### PR DESCRIPTION
Without it `stack sdist` does not work.