### PR TITLE
Seperate ghcjs-boot-clone and ghcjs-boot-prepare checkpoints.

### DIFF
--- a/src-bin/Boot.hs
+++ b/src-bin/Boot.hs
@@ -582,6 +582,7 @@ installDevelopmentTree = subTop $ do
            git_ ["pull"]
       git_ ["submodule", "update", "--init", "--recursive"]
     initGhcjsBoot = sub $ do
+      cd "ghcjs-boot"
       git_ ["reset", "HEAD", "--hard"]
       git_ ["clean", "-f", "-d"]
       mapM_ patchPackage =<< allPackages

--- a/src-bin/Boot.hs
+++ b/src-bin/Boot.hs
@@ -583,8 +583,11 @@ installDevelopmentTree = subTop $ do
       git_ ["submodule", "update", "--init", "--recursive"]
     initGhcjsBoot = sub $ do
       cd "ghcjs-boot"
+      -- cleanup first, make it reenterable.
       git_ ["reset", "HEAD", "--hard"]
       git_ ["clean", "-f", "-d"]
+      git_ ["submodule", "deinit", "-f", "."]
+      git_ ["submodule", "update", "--init"]
       mapM_ patchPackage =<< allPackages
       preparePrimops
       buildGenPrim


### PR DESCRIPTION
Much better for slow network connection, don't need to re-download everything
when clone or submodule update failed, just pick up what's left.
