### PR TITLE
Fix linker output ordering for js-sources. Fixes #484

### DIFF
--- a/src/Gen2/Linker.hs
+++ b/src/Gen2/Linker.hs
@@ -206,8 +206,6 @@ link' dflags env settings target include pkgs objFiles jsFiles isRootFun extraSt
           pkgs'       = nub (rtsPkgs ++ rdPkgs ++ reverse objPkgs ++ reverse pkgs)
           pkgs''      = filter (not . (isAlreadyLinked base)) pkgs'
           pkgLibPaths = mkPkgLibPaths pkgs'
-          getPkgLibPaths :: PackageKey -> ([FilePath],[String])
-          getPkgLibPaths k = fromMaybe ([],[]) (lookup k pkgLibPaths)
       (archsDepsMap, archsRequiredUnits) <- loadArchiveDeps env =<<
           getPackageArchives dflags (map snd $ mkPkgLibPaths pkgs')
       pkgArchs <- getPackageArchives dflags (map snd $ mkPkgLibPaths pkgs'')

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-5.13
+resolver: lts-3.6


### PR DESCRIPTION
Here's an overview of what this changes:

The linker code was previously doing 2 things wrong:
* Putting dependency js code into a Map, and then using `M.elems` to get the code back out. This caused the order of the outputted lib code to be sorted by key, not by transitive ordering. This PR changes the use of a Map to use a list instead in order to preserve the appropriate order that code should be output.
* When calculating dependency ordering, the ordering was from direct dependencies -> transitive dependencies, but transitive dependency JS code needs to come before the JS code for packages that depend on the transitive deps. So the simple fix is just to reverse the package ordering before linking.