### PR TITLE
Allow lts-5.18

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-3.6
+resolver: lts-5.18


### PR DESCRIPTION
`lts-6.0` and above don't work, but this does.