### PR TITLE
Fix #494: Allow top level function declarations in ghcjsi

### DIFF
--- a/src/Compiler/GhciMonad.hs
+++ b/src/Compiler/GhciMonad.hs
@@ -20,7 +20,7 @@ module Compiler.GhciMonad (
         TickArray,
         getDynFlags,
 
-        runStmt, runDecls, resume, timeIt, recordBreak, revertCAFs,
+        isStmt, runStmt, runDecls, resume, timeIt, recordBreak, revertCAFs,
 
         printForUser, printForUserPartWay, prettyLocations,
         initInterpBuffering, turnOffBuffering, flushInterpBuffers,
@@ -52,6 +52,10 @@ import System.Environment
 import System.IO
 import Control.Monad
 import GHC.Exts
+
+import qualified Lexer (ParseResult(..), unP, mkPState)
+import qualified Parser (parseStmt)
+import StringBuffer (stringToStringBuffer)
 
 import System.Console.Haskeline (CompletionFunc, InputT)
 import qualified System.Console.Haskeline as Haskeline
@@ -283,6 +287,19 @@ printForUserPartWay doc = do
   unqual <- GHC.getPrintUnqual
   dflags <- getDynFlags
   liftIO $ Outputable.printForUserPartWay dflags stdout (pprUserLength dflags) unqual doc
+
+isStmt :: String -> GHCi Bool
+isStmt stmt = do
+  st <- getGHCiState
+  dflags <- GHC.getInteractiveDynFlags
+
+  let buf = stringToStringBuffer stmt
+      loc = mkRealSrcLoc (fsLit "<interactive>") (line_number st) 1
+      parser = Parser.parseStmt
+
+  case Lexer.unP parser (Lexer.mkPState dflags buf loc) of
+    Lexer.POk _ _ -> return True
+    Lexer.PFailed _ _ -> return False
 
 -- | Run a single Haskell expression
 runStmt :: String -> GHC.SingleStep -> GHCi (Maybe GHC.RunResult)


### PR DESCRIPTION
Patch for https://ghc.haskell.org/trac/ghc/ticket/7253 by @roshats

```
$ ghcjs --interactive
GHCJSi, version 0.2.0-7.10.2: http://www.github.com/ghcjs/ghcjs/  :? for help
Prelude> 
socket.io not found, browser session not available

Prelude> f x = x
Prelude> :t f
f :: t -> t
```