### PR TITLE
Relax dependencies: aeson, lens, data-default, haskell-src-exts & meta

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -141,10 +141,10 @@ Library
                    syb            >= 0.4      && < 0.7,
                    bytestring     >= 0.10     && < 0.11,
                    attoparsec     >= 0.12     && < 0.14,
-                   aeson          >= 0.7      && < 0.10,
+                   aeson          >= 0.7      && < 0.12,
                    text           >= 0.11     && < 1.3,
                    wl-pprint-text >= 1.1      && < 1.2,
-                   lens           >= 4.0      && < 4.14,
+                   lens           >= 4.0      && < 4.16,
                    yaml           >= 0.8      && < 0.9,
                    time,
                    system-filepath,
@@ -152,7 +152,7 @@ Library
                    split          >= 0.2      && < 0.3,
                    deepseq,
                    vector         >= 0.10     && < 0.12,
-                   data-default   >= 0.5      && < 0.6,
+                   data-default   >= 0.5      && < 0.8,
                    array          >= 0.4      && < 0.6,
                    binary         >= 0.7      && < 0.8,
                    text-binary    >= 0.1      && < 0.3,
@@ -169,8 +169,8 @@ Library
                    regex-posix                >= 0.90 && < 0.100,
                    safe                       >= 0.3  && < 0.4,
                    parsec                     >= 3.1  && < 3.2,
-                   haskell-src-exts           >= 1.16 && < 1.18,
-                   haskell-src-meta           >= 0.6.0.3  && < 0.7
+                   haskell-src-exts           >= 1.16 && < 1.19,
+                   haskell-src-meta           >= 0.6.0.3  && < 0.8
     if os(Windows)
       build-depends: Win32
     else
@@ -344,7 +344,7 @@ test-suite test
                       deepseq,
                       unordered-containers,
                       shelly               >= 1.5 &&  < 1.7,
-                      data-default         >= 0.5 &&  < 0.6,
+                      data-default         >= 0.5 &&  < 0.8,
                       yaml                 >= 0.8 &&  < 0.9,
                       optparse-applicative,
                       directory,


### PR DESCRIPTION
We are using ghcjs built with these dependency versions.