### PR TITLE
Mention the ghc-8.0 branch in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,8 @@ Installation
 
 GHCJS can be installed with GHC 7.10.2 or later.
 
+(Experimental GHC 8 support is in the `ghc-8.0` branch).
+
 ### Requirements
 
  - GHC 7.10.2 or higher


### PR DESCRIPTION
This is to hopefully remove some surprise factor when someone comes to install `ghcjs` on this version of GHC.