### PR TITLE
Support upgraded ghcjs-boot packages

### DIFF
--- a/lib/etc/boot.yaml
+++ b/lib/etc/boot.yaml
@@ -99,6 +99,7 @@ packages:
     - ./boot/tagged
     - ./boot/text
     - ./boot/unordered-containers
+    - ./boot/uuid/uuid-types
     - ./boot/vector
     - ./ghcjs/ghcjs-base
 


### PR DESCRIPTION
This should go together with: https://github.com/ghcjs/ghcjs-boot/pull/41