### PR TITLE
Support (?) Data.Kind.Type when used as a type for a field with DataKinds

### DIFF
--- a/src/Gen2/ClosureInfo.hs
+++ b/src/Gen2/ClosureInfo.hs
@@ -210,6 +210,9 @@ primTypeVt t = case repType t of
     | st == pr "SmallMutableArray#"  = ArrV
     | st == pr "SmallArray#"         = ArrV
 #endif
+#if __GLASGOW_HASKELL__ >= 801
+    | st == pr "TYPE"                = PtrV -- ?
+#endif
     | st == "Data.Dynamic.Obj"       = PtrV -- ?
     | otherwise = error ("primTypeVt: unrecognized primitive type: " ++ st)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-3.6
+resolver: lts-7.22


### PR DESCRIPTION
Should resolve #580  -- I did a couple of preliminary stress tests with convoluted usages of `TypeInType` and things seem to be ok.  If anyone can think of something for me to test out, I'd be happy to try it as well :)