### PR TITLE
Allow serving static files with GHCJSi

### DIFF
--- a/lib/etc/irunner.js
+++ b/lib/etc/irunner.js
@@ -9,6 +9,9 @@ var h$GHCJSiRecord = // true ||
 
 var h$GHCJSiPort = process.env['GHCJSI_PORT'] || 6400;
 
+/* An optional static directory to serve at root */
+var h$GHCJSiStaticDir = process.env['GHCJSI_STATIC_DIR'];
+
 var h$GHCJSiReplay = process.argv.length > 0 &&
                      process.argv[process.argv.length-1] === 'replay';
 
@@ -33,6 +36,20 @@ var io = null;
 try {
   io = require('socket.io')(server);
 } catch (e) { }
+
+if (h$GHCJSiStaticDir) {
+    try {
+        /* Try to set up a static file server for GHCJSi */
+        var finalhandler = require('finalhandler');
+        var serveStatic  = require('serve-static');
+        var serveStaticDir = serveStatic(h$GHCJSiStaticDir);
+    } catch (e) {
+        console.log("\ncan't set up static file server for " + h$GHCJSiStaticDir);
+        console.log("\nmake sure you have finalhandler and serve-static installed:");
+        console.log("\n\n    npm install finalhandler serve-static\n");
+    }
+}
+
 
 // start listening
 function h$initGHCJSi() {
@@ -77,6 +94,9 @@ function h$startHTTPServer() {
     return;
   } else {
     console.log("\nsocket.io found, browser session available at http://localhost:" + h$GHCJSiPort);
+    if (typeof serveStaticDir !== 'undefined') {
+      console.log("\nserving static files from " + h$GHCJSiStaticDir);
+    }
   }
 
   io.on('connection', function(socket) {
@@ -105,6 +125,8 @@ function h$handleHTTP(req, res) {
   } else if(u.pathname === '/client.js') {
     res.writeHead(200, { 'Content-Type': 'application/javascript' });
     res.end(h$GHCJSi.clientJs);
+  } else if (typeof serveStaticDir !== 'undefined') {
+    serveStaticDir(req, res, finalhandler(req, res));
   } else {
     res.statusCode = 404;
     res.statusMessage = 'not found';


### PR DESCRIPTION
This changes allows to serve static files from GHCJSi browser session and makes it possible to:

- run apps with images, CSS files and other stuff from GHCJSi;
- have custom `ghcjsiClient.html` and/or `ghcjsiClient.js`.

This relies on `finalhandler` and `serve-static` packages which one can install using `npm`:

```
npm install finalhandler serve-static
```

I'm not savvy with nam packages, and there seem to be more alternatives to static file servers.
If you think different packages should be used — feel free to change that.

By default static server is disabled. To serve files set `GHCJSI_STATIC_DIR` environment variable, e.g:

```sh
export GHCJSI_STATIC_DIR=$(pwd)/static
```