### PR TITLE
Things that might be required for Cabal-2.0 (but things might have changed)

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -130,7 +130,7 @@ Library
                      GHCJS.Prim.TH.Serialized
     other-modules: Paths_ghcjs
     build-depends: base           >= 4        && < 5,
-                   Cabal          >= 1.23     && < 1.25,
+                   Cabal          >= 1.23,
                    ghc            >= 7.11     && < 8.1,
                    ghc-boot,
                    ghci,


### PR DESCRIPTION
* Ifdef changes in src-bin/Boot.hs to allow build with
  cabal-install-1.24 or cabal-install-2.  If Cabal-2 is available
  this will prevent builds with cabal-install-1.24, but without
  this patch such builds are always impossible because the
  --allow-boot-library-installs flag is an error.
* Remove upper bound 1.25 on Cabal build dependency.  Cabal-install-2 has
  a build dependency on Cabal>=2, so there is no reason to support
  cabal-install-2 without allowing builds with Cabal-2.