### PR TITLE
Fixes issue with `utils/makePackages.sh` on Mac OSX

### DIFF
--- a/utils/makePackages.sh
+++ b/utils/makePackages.sh
@@ -182,7 +182,7 @@ copy_patch_boot_package_list() {
     for FILE in $LIST; do
       # echo "copying file: $PKGSRC/$FILE"
       # echo "   $PWD"
-      cp -ar "$PKGSRC/$FILE" "."
+      cp -a "$PKGSRC/$FILE" "."
     done
   )
 
@@ -194,7 +194,7 @@ copy_patch_boot_package_list() {
       mkdir -p "$PKGORIG"
       cd "$PKGORIG"
       for FILE in $LIST; do
-        cp -ar "$PKGSRC/$FILE" "."
+        cp -a "$PKGSRC/$FILE" "."
       done
     )
     apply_patch "$PKGDST" "$PKGPATCH"


### PR DESCRIPTION
On Mac OSX, `utils/makePackages.sh` fails due to `cp` command using `-ar` flags together. The script fails with message: `cp: the -R and -r options may not be specified together.`

The `-r` flag is redundant when using '-a' flag on both mac and linux, so there should be no harm in removing it. 

From cp usage on centos 7.x:
>-a, --archive                same as -dR --preserve=all
>-R, -r, --recursive          copy directories recursively

From cp usage on Mac OS X:
>-a    Same as -pPR options.