### PR TITLE
Fixes stack build issue with missing install directory in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -25,7 +25,7 @@ import           Distribution.Simple.Register
 
 import           System.Exit           (ExitCode(..))
 import           System.Directory
-  (doesFileExist, removeFile, renameFile, exeExtension)
+  (createDirectoryIfMissing, doesFileExist, removeFile, renameFile, exeExtension)
 import           System.FilePath
   ((</>), (<.>), splitExtensions, dropExtensions)
 import           System.IO
@@ -154,6 +154,7 @@ copyWrapperW v env descr installDirs exe
     optionsExists <- doesFileExist destOptions
     when (not optionsExists) $ do
       options <- replacePlaceholders env <$> readFile srcOptions
+      createDirectoryIfMissing False b
       withTempFile b "ghcjs-options-XXXXXX.tmp" $ \tmp h -> do
         hPutStr h options
         hClose h
@@ -203,6 +204,7 @@ copyWrapperU v env descr installDirs exe
       wrapperExists <- doesFileExist (b </> destWrapperVer)
       when (not wrapperExists) $ do
         wrapperScript <- replacePlaceholders env <$> readFile srcWrapper
+        createDirectoryIfMissing False b
         withTempFile b "ghcjs-wrapper-XXXXXX.tmp" $
           \tmp h -> do hPutStr h wrapperScript
                        hClose h


### PR DESCRIPTION
When using `stack build` to build ghcjs, the build fails to copy the ghcjs binaries to stack work directory.

```
/Users/mike/Development/external/ghcjs/.stack-work/install/x86_64-osx/lts-10.5/8.2.2/bin: openTempFile: does not exist (No such file or directory)
```

To fix the issue, I had to manually create the bin dir:
```
kibbs-laptop:ghcjs mike$ mkdir -p .stack-work/install/x86_64-osx/lts-10.5/8.2.2/bin
kibbs-laptop:ghcjs mike$ stack build
haddock-api-ghcjs-2.18.1: unregistering
haddock-library-ghcjs-1.4.4: unregistering
haddock-library-ghcjs-1.4.4: build (lib)
haddock-library-ghcjs-1.4.4: copy/register
haddock-api-ghcjs-2.18.1: configure (lib)
haddock-api-ghcjs-2.18.1: build (lib)
haddock-api-ghcjs-2.18.1: copy/register
ghcjs-8.2.0.1: configure (lib + exe)
ghcjs-8.2.0.1: build (lib + exe)
ghcjs-8.2.0.1: copy/register
Completed 3 action(s).
Log files have been written to: /Users/mike/Development/external/ghcjs/.stack-work/logs/
```

The tracked the issue down to the `copyWrapperU`/`copyWrapperW` functions in `Setup.hs`. I fixed the issue by adding a call to `createDirectoryIfMissing` before creating the wrapper script.
