### PR TITLE
Properly enable shared libs when booting

### DIFF
--- a/src-bin/Boot.hs
+++ b/src-bin/Boot.hs
@@ -953,7 +953,7 @@ cabalInstallFlags parmakeGhcjs = do
            -- don't slow down Windows builds too much,
            -- on other platforms we get this more
            -- or less for free, thanks to dynamic-too
-           bool isWindows [ "--enable-shared"] [] ++
+           bool isWindows [] ["--enable-shared"] ++
            catMaybes [ (((bool parmakeGhcjs
                                "--ghcjs-options=-j"
                                "-j")<>) . showT) <$> j


### PR DESCRIPTION
It looks like the bool function was used in the unintended order.