### PR TITLE
Handle macOS with gnu tar, and add note in README about it

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,6 +19,8 @@ $ git submodule update --init
 $ ./utils/makePackages.sh
 ```
 
+If you are building on macOS, you will need the gnu version of tar. You can install this with `brew install gnu-tar`, which makes it accessible at `gtar`. The `./utils/makePackages.sh` will automatically pick up on this.
+
 #### building the compiler
 
 GHCJS depends on a few "local" packages in the source tree. You can use

--- a/utils/updateBootArchive.sh
+++ b/utils/updateBootArchive.sh
@@ -20,7 +20,11 @@ TARGET="$GHCJSROOT/lib"
 cd "$TARGET"
 
 echo "creating boot archive"
-tar --dereference --exclude-backups --exclude-vcs-ignores -X "$SOURCEDIR/updateBootArchive.tarExcludes" -cvf boot.tar boot
+if [ -x "$(command -v gtar)" ]; then
+  gtar --dereference --exclude-backups --exclude-vcs-ignores -X "$SOURCEDIR/updateBootArchive.tarExcludes" -cvf boot.tar boot
+else
+  tar --dereference --exclude-backups --exclude-vcs-ignores -X "$SOURCEDIR/updateBootArchive.tarExcludes" -cvf boot.tar boot
+fi
 rm -f "$TARGET/../data/boot.tar"
 mv boot.tar "$TARGET/../data/boot.tar"
 


### PR DESCRIPTION
macOS uses the BSD version of tar by default, which doesn't support the excludes in `utils/updateBootArchive.hs`, namely `--exclude-backups --exclude-vcs-ignores`.

This PR adds a check if an `gtar` executable exists, and uses that instead, along with a note on how to install GNU tar on macOS via brew.