### PR TITLE
Use <> from Data.Semigroup, not Text.PrettyPrint.Leijen.Text

### DIFF
--- a/src/Gen2/Printer.hs
+++ b/src/Gen2/Printer.hs
@@ -13,9 +13,9 @@ import qualified Data.Text                    as T
 
 import           Text.PrettyPrint.Leijen.Text (Doc, align, char, comma,
                                                fillSep, hcat, nest, parens,
-                                               punctuate, text, vcat, (<+>),
-                                               (<>))
+                                               punctuate, text, vcat, (<+>))
 import qualified Text.PrettyPrint.Leijen.Text as PP
+import           Data.Semigroup               ((<>))
 
 import           Compiler.JMacro              (Ident, JExpr(..), JStat(..), JOp(..),
                                                JVal(..), jsToDocR, RenderJs(..), defaultRenderJs)


### PR DESCRIPTION
It is not exported in the versions that build with GHC 8.4