### PR TITLE
Documents that `./utils/makePackages.sh` requires Bash 4.0 or greater

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ $ git submodule update --init --recursive
 $ ./utils/makePackages.sh
 ```
 
-If you are building on macOS, you will need the gnu version of tar. You can install this with `brew install gnu-tar`, which makes it accessible at `gtar`. The `./utils/makePackages.sh` will automatically pick up on this.
+The `./utils/makePackages.sh` script requires Bash version 4.0 or greater. If you are building on macOS, you will need the gnu version of tar. You can install this with `brew install gnu-tar`, which makes it accessible at `gtar`. The `./utils/makePackages.sh` will automatically pick up on this.
 
 #### building the compiler
 


### PR DESCRIPTION
Because it uses the `globstar` option that was introduced by Bash 4.0. The system-provided version of Bash on macOS High Sierra is 3.2.57.

Please note that this also applies to the `ghc-8.4` branch and maybe also others?