### PR TITLE
Fixes a bug in toHsStringMU8.

### DIFF
--- a/lib/boot/shims/src/string.js
+++ b/lib/boot/shims/src/string.js
@@ -699,7 +699,7 @@ function h$toHsStringMU8(arr, cc) {
 #else
 function h$toHsStringMU8(arr) {
 #endif
-    var accept = false, b, n = 0, cp = 0, r = HS_NIL;
+    var i = arr.length - 1, accept = false, b, n = 0, cp = 0, r = HS_NIL;
     while(i >= 0) {
         b = arr[i];
         if(!(b & 128)) {


### PR DESCRIPTION
The variable `i` wasn't initialized.