### PR TITLE
add missing primops for resizeMutableByteArray, shrinkByteArray, and getSizeofMutableByteArray

### DIFF
--- a/src/Gen2/Prim.hs
+++ b/src/Gen2/Prim.hs
@@ -294,6 +294,21 @@ genPrim _ _ ShrinkMutableByteArrayOp_Char [] [a,n] =
                    `a`.dv = r.dv;
                  }
                |]
+genPrim _ _ CompareByteArraysOp [r] [a1,o1,a2,o2,n] =
+  PrimInline [j| `r` = 0;
+                 for (var i=0; i < `n`; i++) {
+                   var x = `a1`.u8[i + `o1`];
+                   var y = `a2`.u8[i + `o2`];
+                   if(x < y) {
+                     `r` = (-1);
+                     break;
+                   }
+                   if(x > y) {
+                     `r` = 1;
+                     break;
+                   }
+                 }
+               |]
 genPrim d t CopyMutableArrayOp  [] [a1,o1,a2,o2,n] =
   genPrim d t CopyArrayOp [] [a1,o1,a2,o2,n]
 genPrim _ _ CloneArrayOp        [r] [a,start,n] =

--- a/src/Gen2/Prim.hs
+++ b/src/Gen2/Prim.hs
@@ -409,8 +409,8 @@ genPrim _ _ WriteByteArrayOp_Float [] [a,i,e] = PrimInline [j| `a`.f3[`i`] = `e`
 genPrim _ _ WriteByteArrayOp_Double [] [a,i,e] = PrimInline [j| `a`.f6[`i`] = `e`; |]
 genPrim _ _ WriteByteArrayOp_StablePtr [] [a,i,_e1,e2]     = PrimInline [j| `a`.i3[`i`] = `e2`; |]
 
-genPrim _ _ WriteByteArrayOp_Int8 [] [a,i,e] = PrimInline [j| `a`.dv.setInt8(`i`, `e`, false); |]
-genPrim _ _ WriteByteArrayOp_Int16 [] [a,i,e]     = PrimInline [j| `a`.dv.setInt16(`i`<<1, `e`, false); |]
+genPrim _ _ WriteByteArrayOp_Int8 [] [a,i,e] = PrimInline [j| `a`.dv.setInt8(`i`, `e`, true); |]
+genPrim _ _ WriteByteArrayOp_Int16 [] [a,i,e]     = PrimInline [j| `a`.dv.setInt16(`i`<<1, `e`, true); |]
 genPrim _ _ WriteByteArrayOp_Int32 [] [a,i,e]     = PrimInline [j| `a`.i3[`i`] = `e`; |]
 genPrim _ _ WriteByteArrayOp_Int64 [] [a,i,e1,e2] =
   PrimInline [j| `a`.i3[(`i`<<1)+1] = `e1`;

--- a/src/Gen2/Prim.hs
+++ b/src/Gen2/Prim.hs
@@ -264,6 +264,36 @@ genPrim _ _ CopyArrayOp         [] [a,o1,ma,o2,n] =
                    `ma`[i+`o2`] = `a`[i+`o1`];
                  }
                |]
+-- This implementation does not perform in-place shrinking of the byte array.
+-- It only reuses the original byte array if the new given length is exactly
+-- equal to old length. This implementation matches the expected semantics
+-- for this primitive, but it is probably possible to make this more efficient.
+genPrim _ _ ResizeMutableByteArrayOp_Char [r] [a,n] = 
+  PrimInline [j| if(`a`.len == `n`) {
+                   `r` = `a`;
+                 } else {
+                   `r` = h$newByteArray(`n`);
+                   for(var i=`n` - 1; i >= 0; i--) {
+                     `r`.u8[i] = `a`.u8[i];
+                   }
+                 }
+               |]
+genPrim _ _ ShrinkMutableByteArrayOp_Char [] [a,n] = 
+  PrimInline [j| if(`a`.len != `n`) {
+                   var r = h$newByteArray(`n`);
+                   for(var i=`n` - 1; i >= 0; i--) {
+                     r.u8[i] = `a`.u8[i];
+                   }
+                   `a`.buf = r.buf;
+                   `a`.len = r.len;
+                   `a`.i3 = r.i3;
+                   `a`.u8 = r.u8;
+                   `a`.u1 = r.u1;
+                   `a`.f3 = r.f3;
+                   `a`.f6 = r.f6;
+                   `a`.dv = r.dv;
+                 }
+               |]
 genPrim d t CopyMutableArrayOp  [] [a1,o1,a2,o2,n] =
   genPrim d t CopyArrayOp [] [a1,o1,a2,o2,n]
 genPrim _ _ CloneArrayOp        [r] [a,start,n] =
@@ -287,6 +317,7 @@ genPrim _ _ SameMutableByteArrayOp [r] [a,b] =
 genPrim _ _ UnsafeFreezeByteArrayOp [a] [b] = PrimInline [j| `a` = `b`; |]
 genPrim _ _ SizeofByteArrayOp [r] [a] = PrimInline [j| `r` = `a`.len; |]
 genPrim _ _ SizeofMutableByteArrayOp [r] [a] = PrimInline [j| `r` = `a`.len; |]
+genPrim _ _ GetSizeofMutableByteArrayOp [r] [a] = PrimInline [j| `r` = `a`.len; |]
 genPrim _ _ IndexByteArrayOp_Char [r] [a,i] = PrimInline [j| `r` = `a`.u8[`i`]; |]
 genPrim _ _ IndexByteArrayOp_WideChar [r] [a,i] = PrimInline [j| `r` = `a`.i3[`i`]; |]
 genPrim _ _ IndexByteArrayOp_Int [r] [a,i] = PrimInline [j| `r` = `a`.i3[`i`]; |]


### PR DESCRIPTION
Someone should look this over since I've never committed anything to GHCJS before. Resolves https://github.com/ghcjs/ghcjs/issues/686