### PR TITLE
ghcjs-8.4: Update text shim to match bundled boot lib version

### DIFF
--- a/lib/boot/shims/pkg/text.js
+++ b/lib/boot/shims/pkg/text.js
@@ -93,7 +93,7 @@ function h$_hs_text_decode_utf8_internal ( dest_v, dest_o_zero
   s.state = state;
   s.codepoint = codepoint;
   destoff_v.dv.setUint32(destoff_o,dsto>>1,true);
-  RETURN_UBX_TUP2(src_v, srco);
+  RETURN_UBX_TUP2(src_v, s.last);
 }
 
 function h$_hs_text_decode_utf8_state( dest_v, dest_o_zero
@@ -119,7 +119,6 @@ function h$_hs_text_decode_utf8_state( dest_v, dest_o_zero
   src_v.arr[src_o][1] = s.last;
   state0_v.dv.setUint32(state0_o, s.state, true);
   codepoint0_v.dv.setUint32(codepoint0_o, s.codepoint, true);
-  if(s.state === TEXT_UTF8_REJECT) ret1--;
   RETURN_UBX_TUP2(ret, ret1);
 }
 
@@ -142,7 +141,6 @@ function h$_hs_text_decode_utf8( dest_v, dest_o_zero
                                                  , srcend_v, srcend_o
                                                  , s
                                                  ));
-  if (s.state !== TEXT_UTF8_ACCEPT) ret1--;
   RETURN_UBX_TUP2(ret, ret1);
 }
 


### PR DESCRIPTION
with changes from https://github.com/haskell/text/pull/182
bundled in version 1.2.3.0. This also gets the new decoding tests
to pass which expect the new behavior