### PR TITLE
README: Improve cloning instructions for ghc-8.2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ installed under the name `ghc-api-ghcjs`
 #### getting and preparing the source tree
 
 ```
-$ git clone https://github.com/ghcjs/ghcjs.git
+$ git clone --branch ghc-8.2 https://github.com/ghcjs/ghcjs.git
 $ cd ghcjs
 $ git submodule update --init --recursive
 $ ./utils/makePackages.sh


### PR DESCRIPTION
The current cloning instructions in branch ghc-8.2 are incomplete. They clone the master branch instead of branch ghc-8.2. So the installation fails with **bash: ./utils/makePackages.sh not found**.

Here is the log: 

```
roland@goms:~/Projekte$ git clone https://github.com/ghcjs/ghcjs.git
Klone nach 'ghcjs' ...
remote: Enumerating objects: 75, done.
remote: Counting objects: 100% (75/75), done.
remote: Compressing objects: 100% (48/48), done.
remote: Total 10068 (delta 31), reused 52 (delta 18), pack-reused 9993
Empfange Objekte: 100% (10068/10068), 5.54 MiB | 3.37 MiB/s, Fertig.
Löse Unterschiede auf: 100% (5291/5291), Fertig.
roland@goms:~/Projekte$ cd ghcjs
roland@goms:~/Projekte/ghcjs$ git submodule update --init --recursive
roland@goms:~/Projekte/ghcjs$ ./utils/makePackages.sh
bash: ./utils/makePackages.sh: Datei oder Verzeichnis nicht gefunden          <--- ERROR !!
roland@goms:~/Projekte/ghcjs$ git branch
* master
```

This PR improves the cloning instructions.