### PR TITLE
Preserve comments when performing doCpp on JS files only (it's very unlikely that it fixes #735)

### DIFF
--- a/src/Compiler/Utils.hs
+++ b/src/Compiler/Utils.hs
@@ -223,6 +223,10 @@ doCpp dflags raw input_fn output_fn = do
                     ++ map SysTools.Option sse_defs
                     ++ map SysTools.Option avx_defs
                     ++ mb_macro_include
+        -- Preserve comments, as these are imortant for closure compiler, and the
+        -- preprocessor can mistake slashes in regular expressions for the start of
+        -- a comment
+                    ++ [ SysTools.Option     "-CC" | isJsFile input_fn ]
         -- Set the language mode to assembler-with-cpp when preprocessing. This
         -- alleviates some of the C99 macro rules relating to whitespace and the hash
         -- operator, which we tend to abuse. Clang in particular is not very happy


### PR DESCRIPTION
That's probably too simplistic, but I just preserve the comments when `isJsFile` is true for the file name. Disclaimer: I don't know what I'm doing.

Having said that, results are encouraging. Applying Closure Compiler before the PR to this file

    -rw-rw-r-- 1 mikolaj mikolaj 23528224 Mar 17 10:05 all.js

results in

    0 error(s), 539 warning(s), 46.2% typed

    -rw-rw-r-- 1 mikolaj mikolaj  6481297 Mar 17 10:54 lambdahack.all.js

and after the PR, stats are as follows:

    -rw-rw-r-- 1 mikolaj mikolaj 23711606 Mar 17 18:15 all.js

    0 error(s), 360 warning(s), 46.4% typed

    -rw-rw-r-- 1 mikolaj mikolaj  6483643 Mar 17 18:34 lambdahack.all.js

The invocation is

```
npx google-closure-compiler /home/mikolaj/r/LambdaHack/dist-newstyle/build/x86_64-linux/ghcjs-8.6.0.1/LambdaHack-0.9.1.0/x/LambdaHack/build/LambdaHack/LambdaHack.jsexe/all.js --compilation_level=ADVANCED_OPTIMIZATIONS --isolation_mode=IIFE --assume_function_wrapper --externs=/home/mikolaj/r/LambdaHack/dist-newstyle/build/x86_64-linux/ghcjs-8.6.0.1/LambdaHack-0.9.1.0/x/LambdaHack/build/LambdaHack/LambdaHack.jsexe/all.js.externs --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/assert.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/child_process.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/crypto.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/dns.js     --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/events.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/globals.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/https.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/os.js    --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/punycode.js     --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/readline.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/stream.js          --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/tls.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/url.js   --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/vm.js --externs=/home/mikolaj/waste/buffer.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/cluster.js        --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/dgram.js   --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/domain.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/fs.js      --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/http.js     --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/net.js    --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/path.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/querystring.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/repl.js      --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/string_decoder.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/tty.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/util.js  --externs=/home/mikolaj/.nvm/node_modules/google-closure-compiler/contrib/nodejs/zlib.js --jscomp_off=checkVars > ../lambdahack.github.io/lambdahack.all.js
```

without `--jscomp_off=checkVars`, both before and after the PR I get errors

    149 error(s), 13 warning(s)

The full list of errors and warning will be posted in #723.






