### PR TITLE
Added working stack install instructions + other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ cabal.sandbox.config
 /lib/cache/build
 .stack-work/
 .cabal-sandbox/
+build.yaml

--- a/README.markdown
+++ b/README.markdown
@@ -26,21 +26,15 @@ The `./utils/makePackages.sh` script requires Bash version 4.0 or greater. If yo
 ##### stack
 These instructions assumes you have used `stack setup` to install ghc, but ghc is not in your PATH.
 
-Create a stack.yaml without dependencies based on original ghcjs/stack.yaml
-This allows usages of `stack exec` to bring ghc and other stack built binaries into scope.
-```
-$ grep '^\s*resolver:' stack.yaml > ghcjs.yaml
-```
-
 `./utils/makePackages.sh` requirements
 ```
-$ stack --stack-yaml=ghcjs.yaml build cabal-install happy alex
-$ stack --stack-yaml=ghcjs.yaml exec cabal v1-update
+$ stack build cabal-install happy alex
+$ stack exec cabal v1-update
 ```
 
 Now you can run `./utils/makePackages.sh`
 ```
-$ stack --stack-yaml=ghcjs.yaml exec --no-ghc-package-path ./utils/makePackages.sh
+$ stack exec --no-ghc-package-path ./utils/makePackages.sh
 ```
 
 ### cabal
@@ -98,14 +92,15 @@ $ cabal install
 or you can use stack:
 
 
-To just compile
+To compile
 ```
-$ stack build
+$ cat stack.yaml build.extra.yaml > build.yaml
+$ stack --stack-yaml=build.yaml build
 ```
 
-To compile and install the executables and wrapper scripts
+To install the executables and wrapper scripts
 ```
-$ stack install
+$ stack --stack-yaml=build.yaml install
 ```
 
 #### Booting GHCJS
@@ -119,7 +114,7 @@ $ ghcjs-boot
 
 Alternatively, if you are using stack and don't have ghc in your PATH.
 ```
-$ stack --stack-yaml=ghcjs.yaml exec ghcjs-boot
+$ stack --stack-yaml=build.yaml exec ghcjs-boot
 ```
 
 when invoked without arguments, ghcjs-boot will build the libraries from

--- a/README.markdown
+++ b/README.markdown
@@ -98,9 +98,16 @@ $ cat stack.yaml build.extra.yaml > build.yaml
 $ stack --stack-yaml=build.yaml build
 ```
 
-To install the executables and wrapper scripts
+To install the executables into `~/.local/bin`
 ```
 $ stack --stack-yaml=build.yaml install
+$ cd ~/local/bin
+$ ln -s ghcjs-run runghcjs # stack expects runghcjs
+```
+
+To use stack to compile ghcjs programs, use the following prefix
+```
+stack --system-ghc --compiler ghcjs-8.6.0.1_ghc-8.6.5 [stack_commands]
 ```
 
 #### Booting GHCJS
@@ -114,7 +121,7 @@ $ ghcjs-boot
 
 Alternatively, if you are using stack and don't have ghc in your PATH.
 ```
-$ stack --stack-yaml=build.yaml exec ghcjs-boot
+$ stack exec ghcjs-boot
 ```
 
 when invoked without arguments, ghcjs-boot will build the libraries from

--- a/README.markdown
+++ b/README.markdown
@@ -16,10 +16,44 @@ installed under the name `ghc-api-ghcjs`
 $ git clone --branch ghc-8.6 https://github.com/ghcjs/ghcjs.git
 $ cd ghcjs
 $ git submodule update --init --recursive
-$ ./utils/makePackages.sh
 ```
 
+#### preparing the required packages
+
 The `./utils/makePackages.sh` script requires Bash version 4.0 or greater. If you are building on macOS, you will need the gnu version of tar. You can install this with `brew install gnu-tar`, which makes it accessible at `gtar`. The `./utils/makePackages.sh` will automatically pick up on this.
+
+
+##### stack
+These instructions assumes you have used `stack setup` to install ghc, but ghc is not in your PATH.
+
+Create a stack.yaml without dependencies based on original ghcjs/stack.yaml
+This allows usages of `stack exec` to bring ghc and other stack built binaries into scope.
+```
+$ grep '^\s*resolver:' stack.yaml > ghcjs.yaml
+```
+
+`./utils/makePackages.sh` requirements
+```
+$ stack --stack-yaml=ghcjs.yaml build cabal-install happy alex
+$ stack --stack-yaml=ghcjs.yaml exec cabal v1-update
+```
+
+Now you can run `./utils/makePackages.sh`
+```
+$ stack --stack-yaml=ghcjs.yaml exec --no-ghc-package-path ./utils/makePackages.sh
+```
+
+### cabal
+Alternatively, install [cabal](https://www.haskell.org/cabal/download.html)
+These instructions assumes that you do have ghc in your PATH.
+```
+# ./utils/makePackages.sh requirements
+$ cabal v1-update
+$ cabal v1-install happy alex
+
+# now you can run ./utils/makePackages.sh
+$ ./utils/makePackages.sh # assumes you already have ghc in your PATH.
+```
 
 #### building the compiler
 
@@ -63,8 +97,15 @@ $ cabal install
 
 or you can use stack:
 
+
+To just compile
 ```
 $ stack build
+```
+
+To compile and install the executables and wrapper scripts
+```
+$ stack install
 ```
 
 #### Booting GHCJS
@@ -74,6 +115,11 @@ Haskell programs and packages.
 
 ```
 $ ghcjs-boot
+```
+
+Alternatively, if you are using stack and don't have ghc in your PATH.
+```
+$ stack --stack-yaml=ghcjs.yaml exec ghcjs-boot
 ```
 
 when invoked without arguments, ghcjs-boot will build the libraries from

--- a/build.extra.yaml
+++ b/build.extra.yaml
@@ -1,0 +1,13 @@
+# the source tree needs to be "booted" for this stack.yaml file to be usable:
+#
+# $ git submodule update --init --recursive
+# $ ./utils/makePackages.sh
+#
+packages:
+  - .
+  - ./lib/ghc-api-ghcjs
+  - ./lib/ghci-ghcjs
+  - ./lib/ghcjs-th
+  - ./lib/haddock-api-ghcjs
+  - ./lib/haddock-library-ghcjs
+  - ./lib/template-haskell-ghcjs

--- a/lib/boot/boot.yaml
+++ b/lib/boot/boot.yaml
@@ -51,9 +51,11 @@ packages:
     - ./pkg/template-haskell
     - ./pkg/parsec
     - ./pkg/process
+    - ./pkg/stm
     - ./pkg/time
     - ./pkg/text
     - ./pkg/mtl
+    - ./pkg/xhtml
     - IfUnix:    ./pkg/unix
     - IfWindows: ./pkg/Win32
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: lts-14.7
 extra-deps:
   - haskell-src-exts-1.20.3@sha256:eb9a0a02e422f64e793fe077e445e930bc365b7f7ce92ce6983475c72f8b3785,4467
   - happy-1.19.9@sha256:f8c774230735a390c287b2980cfcd2703d24d8dde85a01ea721b7b4b4c82944f,4667
+  # Keep Cabal versions consistent with GHC version, just in case
   - Cabal-2.4.0.1
   - cabal-install-2.4.0.0
   - resolv-0.1.1.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,9 @@
-# the source tree needs to be "booted" for this stack.yaml file to be usable:
-#
-# $ git submodule update --init --recursive
-# $ ./utils/makePackages.sh
-#
-
 resolver: lts-14.7
+
 extra-deps:
   - haskell-src-exts-1.20.3@sha256:eb9a0a02e422f64e793fe077e445e930bc365b7f7ce92ce6983475c72f8b3785,4467
   - happy-1.19.9@sha256:f8c774230735a390c287b2980cfcd2703d24d8dde85a01ea721b7b4b4c82944f,4667
-packages:
-  - .
-  - ./lib/ghc-api-ghcjs
-  - ./lib/ghci-ghcjs
-  - ./lib/ghcjs-th
-  - ./lib/haddock-api-ghcjs
-  - ./lib/haddock-library-ghcjs
-  - ./lib/template-haskell-ghcjs
+  - Cabal-2.4.0.1
+  - cabal-install-2.4.0.0
+  - resolv-0.1.1.2
+  - zip-archive-0.3.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@
 # $ ./utils/makePackages.sh
 #
 
-resolver: lts-14.2 
+resolver: lts-14.7
 extra-deps:
   - haskell-src-exts-1.20.3@sha256:eb9a0a02e422f64e793fe077e445e930bc365b7f7ce92ce6983475c72f8b3785,4467
   - happy-1.19.9@sha256:f8c774230735a390c287b2980cfcd2703d24d8dde85a01ea721b7b4b4c82944f,4667

--- a/utils/makePackages.sh
+++ b/utils/makePackages.sh
@@ -309,7 +309,7 @@ for PKG in base array binary bytestring containers deepseq directory \
            filepath ghc-boot ghc-heap ghc-compact \
            ghc-boot-th ghci integer-gmp integer-simple \
            parallel pretty process stm template-haskell \
-           mtl parsec text time transformers unix Win32; do
+           mtl parsec text time transformers xhtml unix Win32; do
   copy_patch_boot_package_sdist "$PKG" ""
 done
 

--- a/utils/makePackages.sh
+++ b/utils/makePackages.sh
@@ -65,11 +65,7 @@ GHCSRC="$GHCJSROOT/ghc"
 WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/$(basename $0).XXXXXXXXXXXX")
 
 CABALVER=$(cabal --numeric-version)
-if [[ ${CABALVER:0:2} != "1." && ${CABALVER:0:2} != "2." ]]; then
-  CMDPREFIX="v1-"
-else
-  CMDPREFIX=""
-fi
+CMDPREFIX="v1-"
 
 # we need ln to support the -r option.
 # the BSD ln program on macOS doesn't support it
@@ -261,6 +257,7 @@ then
 (
 mkdir -p inplace/bin
 cd utils/genprimopcode
+echo 'packages: genprimopcode.cabal' > cabal.project
 cabal ${CMDPREFIX}build --builddir=dist
 gnucp dist/build/genprimopcode/genprimopcode ../../inplace/bin
 )


### PR DESCRIPTION
I just successfully compiled ghcjs from a "clean" (deleted stack, cabal, and installed binaries) os, and the instructions on the README was insufficient.
I updated the README to included stack instruction that worked.

This pull request made a few other changes:

1. Update to lts-14.7 - still ghc 8.6.5
2. Removed support for plain cabal, CMDPREFIX is hardcoded to "v1". This was because lts-14.7 installs Cabal-2.4.1.0 which supports "v1"
3. Added generation of genprimopcode/cabal.project to support cabal v1-build
