### PR TITLE
Standard tools

### DIFF
--- a/ghcjs.cabal
+++ b/ghcjs.cabal
@@ -1,5 +1,5 @@
 Name:           ghcjs
-Version:        8.6.0.1
+Version:        8.6.5
 Synopsis:       Haskell to JavaScript compiler
 Description:    Haskell to JavaScript compiler based on GHC
 Category:       compiler, web

--- a/lib/boot/Makefile
+++ b/lib/boot/Makefile
@@ -1,0 +1,215 @@
+# Expect the whole build process to have been completed until the `ghcjs-boot` process is started.
+
+# We expect to have a `ghcjs` binary in `.bin` or somewhere. And a `ghc` binary for the host.
+
+# enter some shell
+# nix-shell --pure -p '[ stdenv ghc cabal-install which zlib zlib.dev git cacert haskellPackages.alex haskellPackages.happy bash autoconf automake less ]'
+
+# Need this to sidestep booting restrictions in ghcjs
+# export GHCJS_BOOTING=1
+# need this as cabal otherwise defines this, but won't unless --ghcjs is provided.
+# also ghcjs lies about it's target. And fails to claim it's a cross compiler!
+# export CFLAGS="-D__GHCJS__ -Dghcjs_HOST_OS -I/p/iohk/ghcjs/lib/ghc-api-ghcjs/includes -I/p/iohk/ghcjs/lib/boot/data/include -I/usr/local/Cellar/gmp/6.1.2_2/include"
+
+# Install some fake rts
+# cat fake-rts.conf | ghc-pkg --global-package-db=inst/package.conf register -
+# where fake-rts is
+#  name: rts
+#  version: 1.0
+#  id: rts
+#  key: rts
+#  license: BSD-3-Clause
+#  maintainer: glasgow-haskell-users@haskell.org
+#  exposed: True
+
+# For each library:
+# 1. build the Setup.hs with $(HOST_HC)
+# 2. $(HC_PKG) init inst/package.conf
+# 3. run ./Setup configure --with-ghc=$(CROSS_HC) --disable-library-stripping --disable-executable-stripping --prefix=$PWD/inst --package-db=clear --package-db=$PWD/inst/package.conf
+# 4. run ./Setup build
+# 5. run ./Setup register --gen-pkg-config=$(PKG).conf
+# 5. $(HC_PKG) --global-package-db=inst/package.conf register $(PKG).conf
+
+HC_PKG:=ghc-pkg
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+PKG_DB:=$(ROOT_DIR)/inst/package.conf
+HOST_HC:=ghc
+GHCJS_BOOTING=1
+
+# We'll need those in commands we call.
+# Make sure HOST_HC and HC are in the environment.
+export HOST_HC
+export HC
+export GHCJS_BOOTING
+export CFLAGS
+#export CFLAGS="-D__GHCJS__ -Dghcjs_HOST_OS -I/p/iohk/ghcjs/lib/ghc-api-ghcjs/includes -I/p/iohk/ghcjs/lib/boot/data/include -I/usr/local/Cellar/gmp/6.1.2_2/include $(CFLAGS)"
+
+inst/package.conf :
+	$(HC_PKG) init $@
+
+inst/package.conf/rts.conf : inst/package.conf
+	cat fake-rts.conf | $(HC_PKG) --global-package-db=$(PKG_DB) register --force - || true
+
+inst/package.conf/ghc-prim.conf : inst/package.conf/rts.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghc-prim \
+		ghc-prim
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-prim/ghc-prim.conf
+
+inst/package.conf/integer-gmp.conf : inst/package.conf/ghc-prim.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/integer-gmp \
+		integer-gmp \
+		--extra-include-dirs=/usr/local/Cellar/gmp/6.1.2_2/include
+	# Need the extra-include-dirs, to ensure we find <gmp.h>
+
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/integer-gmp/integer-gmp.conf
+
+inst/package.conf/base.conf : inst/package.conf/integer-gmp.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/base \
+		base \
+		--extra-include-dirs=/p/iohk/ghcjs/lib/ghc-api-ghcjs/includes \
+		--extra-include-dirs=I/p/iohk/ghcjs/lib/boot/data/include
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/base/base.conf
+
+inst/package.conf/transformers.conf : inst/package.conf/base.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/transformers \
+		transformers
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/transformers/transformers.conf
+
+inst/package.conf/ghcjs-prim.conf : inst/package.conf/transformers.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghcjs-prim \
+		ghcjs-prim
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghcjs-prim/ghcjs-prim.conf
+
+inst/package.conf/array.conf : inst/package.conf/ghcjs-prim.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/array \
+		array
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/array/array.conf
+
+inst/package.conf/bytestring.conf : inst/package.conf/array.conf inst/package.conf/deepseq.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/bytestring \
+		bytestring
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/bytestring/bytestring.conf
+
+inst/package.conf/containers.conf : inst/package.conf/bytestring.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/containers \
+		containers
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/containers/containers.conf
+
+inst/package.conf/binary.conf : inst/package.conf/containers.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/binary \
+		binary
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/binary/binary.conf
+
+inst/package.conf/deepseq.conf : inst/package.conf/array.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/deepseq \
+		deepseq
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/deepseq/deepseq.conf
+
+inst/package.conf/directory.conf : inst/package.conf/filepath.conf inst/package.conf/time.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/directory \
+		directory
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/directory/directory.conf
+
+inst/package.conf/filepath.conf : inst/package.conf/base.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/filepath \
+		filepath
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/filepath/filepath.conf
+
+inst/package.conf/ghc.conf : inst/package.conf/ghc-boot.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghc \
+		ghc
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc/ghc.conf
+
+inst/package.conf/ghc-boot.conf : inst/package.conf/directory.conf inst/package.conf/filepath.conf inst/package.conf/ghc-boot-th.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghc-boot \
+		ghc-boot
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-boot/ghc-boot.conf
+
+inst/package.conf/ghc-boot-th.conf : inst/package.conf/base.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghc-boot-th \
+		ghc-boot-th
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-boot-th/ghc-boot-th.conf
+
+inst/package.conf/ghc-compact.conf : inst/package.conf/bytestring.conf inst/package.conf/ghc-prim.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghc-compact \
+		ghc-compact
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-compact/ghc-compact.conf
+
+inst/package.conf/ghc-heap.conf : inst/package.conf/ghc-prim.conf inst/package.conf/base.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghc-heap \
+		ghc-heap
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-heap/ghc-heap.conf
+
+inst/package.conf/ghci.conf : inst/package.conf/template-haskell.conf inst/package.conf/transformers.conf inst/package.conf/filepath.conf inst/package.conf/ghc-boot.conf inst/package.conf/ghc-heap.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/ghci \
+		ghci
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghci/ghci.conf
+
+inst/package.conf/pretty.conf : inst/package.conf/deepseq.conf inst/package.conf/ghc-prim.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/pretty \
+		pretty
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/pretty/pretty.conf
+
+inst/package.conf/template-haskell.conf : inst/package.conf/ghc-boot-th.conf inst/package.conf/pretty.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/template-haskell \
+		template-haskell
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/template-haskell/template-haskell.conf
+
+inst/package.conf/parsec.conf : inst/package.conf/mtl.conf inst/package.conf/text.conf inst/package.conf/bytestring.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/parsec \
+		parsec
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/parsec/parsec.conf
+
+inst/package.conf/process.conf : inst/package.conf/directory.conf inst/package.conf/deepseq.conf inst/package.conf/ghcjs-prim.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/process \
+		process
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/process/process.conf
+
+inst/package.conf/time.conf : inst/package.conf/deepseq.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/time \
+		time
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/time/time.conf
+
+inst/package.conf/text.conf : inst/package.conf/deepseq.conf inst/package.conf/bytestring.conf inst/package.conf/array.conf inst/package.conf/ghc-prim.conf inst/package.conf/binary.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/text \
+		text
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/text/text.conf
+
+inst/package.conf/mtl.conf : inst/package.conf/transformers.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/mtl \
+		mtl
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/mtl/mtl.conf
+
+inst/package.conf/unix.conf : inst/package.conf/time.conf inst/package.conf/bytestring.conf
+	./build-package.sh $(PKG_DB) \
+		$(ROOT_DIR)/pkg/unix \
+		unix
+	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/unix/unix.conf
+
+clean :
+	rm -fR inst/package.conf

--- a/lib/boot/Makefile
+++ b/lib/boot/Makefile
@@ -2,6 +2,8 @@
 
 # We expect to have a `ghcjs` binary in `.bin` or somewhere. And a `ghc` binary for the host.
 
+
+
 # enter some shell
 # nix-shell --pure -p '[ stdenv ghc cabal-install which zlib zlib.dev git cacert haskellPackages.alex haskellPackages.happy bash autoconf automake less ]'
 
@@ -12,7 +14,7 @@
 # export CFLAGS="-D__GHCJS__ -Dghcjs_HOST_OS -I/p/iohk/ghcjs/lib/ghc-api-ghcjs/includes -I/p/iohk/ghcjs/lib/boot/data/include -I/usr/local/Cellar/gmp/6.1.2_2/include"
 
 # Install some fake rts
-# cat fake-rts.conf | ghc-pkg --global-package-db=inst/package.conf register -
+# cat fake-rts.conf | ghc-pkg --global-package-db=$(FULL_PKG_DB) register -
 # where fake-rts is
 #  name: rts
 #  version: 1.0
@@ -24,15 +26,17 @@
 
 # For each library:
 # 1. build the Setup.hs with $(HOST_HC)
-# 2. $(HC_PKG) init inst/package.conf
-# 3. run ./Setup configure --with-ghc=$(CROSS_HC) --disable-library-stripping --disable-executable-stripping --prefix=$PWD/inst --package-db=clear --package-db=$PWD/inst/package.conf
+# 2. $(HC_PKG) init $(PKG_DB)
+# 3. run ./Setup configure --with-ghc=$(CROSS_HC) --disable-library-stripping --disable-executable-stripping --prefix=$PWD/inst --package-db=clear --package-db=$PWD/$(PKG_DB)
 # 4. run ./Setup build
 # 5. run ./Setup register --gen-pkg-config=$(PKG).conf
-# 5. $(HC_PKG) --global-package-db=inst/package.conf register $(PKG).conf
+# 5. $(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(PKG).conf
 
 HC_PKG:=ghc-pkg
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-PKG_DB:=$(ROOT_DIR)/inst/package.conf
+GHC_LIB_DIR:=$(shell ghc --info | runghc Settings.hs LibDir)
+PKG_DB:=inst/lib/package.conf.d
+FULL_PKG_DB:=$(ROOT_DIR)/inst/lib/package.conf.d
 HOST_HC:=ghc
 GHCJS_BOOTING=1
 
@@ -44,172 +48,232 @@ export GHCJS_BOOTING
 export CFLAGS
 #export CFLAGS="-D__GHCJS__ -Dghcjs_HOST_OS -I/p/iohk/ghcjs/lib/ghc-api-ghcjs/includes -I/p/iohk/ghcjs/lib/boot/data/include -I/usr/local/Cellar/gmp/6.1.2_2/include $(CFLAGS)"
 
-inst/package.conf :
+.PHONY: inst/lib
+
+# This frankensteins lots of includes together. It's by far the most messy stuff
+# ever.
+inst/lib :
+	mkdir -p inst/lib/include
+	mkdir -p inst/lib/include_native
+	# cp -r ghc --info `LibDir`/include -> include_native
+	cp -r shims/. inst/lib
+	# copy over settings, llvm-passes and llvm-targets from the
+	# ghc source. (Note: settings us usually created from settings.in)
+	cp -f ../../ghc/settings inst/lib/
+	cp -f ../../ghc/llvm-passes inst/lib
+	cp -f ../../ghc/llvm-targets inst/lib
+
+	# pretend that platformConstants are identical to those from the build.
+	# They are not really, but we'll get away with it.
+	cp -f "$(GHC_LIB_DIR)/platformConstants" inst/lib
+
+	# copy over all the data include stuff we have.
+	cp -r data/include/. inst/lib/include
+	# clone the include_native from the build compiler. This will
+	# be configured for the wrong architecture... but ohh well..
+#	cp -f -r "$(GHC_LIB_DIR)/include/." inst/lib/include_native || true
+	# These should all be part of the `rts`'s includes.
+	cp -f -r ../../ghc/includes/Cmm.h \
+		../../ghc/includes/HsFFI.h \
+		../../ghc/includes/MachDeps.h \
+		../../ghc/includes/Rts.h \
+		../../ghc/includes/RtsAPI.h \
+		../../ghc/includes/Stg.h \
+		../../ghc/includes/ghcconfig.h \
+		inst/lib/include
+	cp -f -r inst/lib/include_native/stg inst/lib/include || true
+	mkdir -p inst/lib/include/rts
+	cp -f -r ../../ghc/rts/*.h inst/lib/include/rts/
+	cp -f -r ../../ghc/includes/rts/* inst/lib/include/rts/
+
+	# js support code
+	cp -r shims inst/lib/
+	cp data/runmain.js inst/lib/
+	cp data/template.html inst/lib/
+	cp data/manifest.webapp inst/lib/
+
+	echo $(GHC_LIB_DIR)
+
+inst/lib/ghcjs_boot.completed :
+	touch inst/lib/ghcjs_boot.completed
+
+inst/lib/wiredinkeys.yaml :
+	echo "ghcjs-prim: ghcjs-prim" > inst/lib/wiredinkeys.yaml
+	echo "ghcjs-th: ghcjs-th" >> inst/lib/wiredinkeys.yaml
+
+$(PKG_DB) :
 	$(HC_PKG) init $@
 
-inst/package.conf/rts.conf : inst/package.conf
-	cat fake-rts.conf | $(HC_PKG) --global-package-db=$(PKG_DB) register --force - || true
+$(PKG_DB)/rts.conf : $(PKG_DB)
+	cat fake-rts.conf | $(HC_PKG) --global-package-db=$(FULL_PKG_DB) register --force - || true
 
-inst/package.conf/ghc-prim.conf : inst/package.conf/rts.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghc-prim.conf : $(PKG_DB)/rts.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghc-prim \
 		ghc-prim
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-prim/ghc-prim.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghc-prim/ghc-prim.conf
 
-inst/package.conf/integer-gmp.conf : inst/package.conf/ghc-prim.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/integer-gmp.conf : $(PKG_DB)/ghc-prim.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/integer-gmp \
 		integer-gmp \
 		--extra-include-dirs=/usr/local/Cellar/gmp/6.1.2_2/include
 	# Need the extra-include-dirs, to ensure we find <gmp.h>
 
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/integer-gmp/integer-gmp.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/integer-gmp/integer-gmp.conf
 
-inst/package.conf/base.conf : inst/package.conf/integer-gmp.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/base.conf : $(PKG_DB)/integer-gmp.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/base \
 		base \
 		--extra-include-dirs=/p/iohk/ghcjs/lib/ghc-api-ghcjs/includes \
 		--extra-include-dirs=I/p/iohk/ghcjs/lib/boot/data/include
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/base/base.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/base/base.conf
 
-inst/package.conf/transformers.conf : inst/package.conf/base.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/transformers.conf : $(PKG_DB)/base.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/transformers \
 		transformers
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/transformers/transformers.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/transformers/transformers.conf
 
-inst/package.conf/ghcjs-prim.conf : inst/package.conf/transformers.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghcjs-prim.conf : $(PKG_DB)/transformers.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghcjs-prim \
 		ghcjs-prim
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghcjs-prim/ghcjs-prim.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghcjs-prim/ghcjs-prim.conf
 
-inst/package.conf/array.conf : inst/package.conf/ghcjs-prim.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/array.conf : $(PKG_DB)/ghcjs-prim.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/array \
 		array
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/array/array.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/array/array.conf
 
-inst/package.conf/bytestring.conf : inst/package.conf/array.conf inst/package.conf/deepseq.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/bytestring.conf : $(PKG_DB)/array.conf $(PKG_DB)/deepseq.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/bytestring \
 		bytestring
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/bytestring/bytestring.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/bytestring/bytestring.conf
 
-inst/package.conf/containers.conf : inst/package.conf/bytestring.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/containers.conf : $(PKG_DB)/bytestring.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/containers \
 		containers
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/containers/containers.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/containers/containers.conf
 
-inst/package.conf/binary.conf : inst/package.conf/containers.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/binary.conf : $(PKG_DB)/containers.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/binary \
 		binary
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/binary/binary.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/binary/binary.conf
 
-inst/package.conf/deepseq.conf : inst/package.conf/array.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/deepseq.conf : $(PKG_DB)/array.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/deepseq \
 		deepseq
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/deepseq/deepseq.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/deepseq/deepseq.conf
 
-inst/package.conf/directory.conf : inst/package.conf/filepath.conf inst/package.conf/time.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/directory.conf : $(PKG_DB)/filepath.conf $(PKG_DB)/time.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/directory \
 		directory
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/directory/directory.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/directory/directory.conf
 
-inst/package.conf/filepath.conf : inst/package.conf/base.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/filepath.conf : $(PKG_DB)/base.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/filepath \
 		filepath
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/filepath/filepath.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/filepath/filepath.conf
 
-inst/package.conf/ghc.conf : inst/package.conf/ghc-boot.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghc.conf : $(PKG_DB)/ghc-boot.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghc \
 		ghc
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc/ghc.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghc/ghc.conf
 
-inst/package.conf/ghc-boot.conf : inst/package.conf/directory.conf inst/package.conf/filepath.conf inst/package.conf/ghc-boot-th.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghc-boot.conf : $(PKG_DB)/directory.conf $(PKG_DB)/filepath.conf $(PKG_DB)/ghc-boot-th.conf $(PKG_DB)/binary.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghc-boot \
 		ghc-boot
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-boot/ghc-boot.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghc-boot/ghc-boot.conf
 
-inst/package.conf/ghc-boot-th.conf : inst/package.conf/base.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghc-boot-th.conf : $(PKG_DB)/base.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghc-boot-th \
 		ghc-boot-th
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-boot-th/ghc-boot-th.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghc-boot-th/ghc-boot-th.conf
 
-inst/package.conf/ghc-compact.conf : inst/package.conf/bytestring.conf inst/package.conf/ghc-prim.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghc-compact.conf : $(PKG_DB)/bytestring.conf $(PKG_DB)/ghc-prim.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghc-compact \
 		ghc-compact
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-compact/ghc-compact.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghc-compact/ghc-compact.conf
 
-inst/package.conf/ghc-heap.conf : inst/package.conf/ghc-prim.conf inst/package.conf/base.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghc-heap.conf : $(PKG_DB)/ghc-prim.conf $(PKG_DB)/base.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghc-heap \
 		ghc-heap
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghc-heap/ghc-heap.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghc-heap/ghc-heap.conf
 
-inst/package.conf/ghci.conf : inst/package.conf/template-haskell.conf inst/package.conf/transformers.conf inst/package.conf/filepath.conf inst/package.conf/ghc-boot.conf inst/package.conf/ghc-heap.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/ghci.conf : $(PKG_DB)/template-haskell.conf $(PKG_DB)/transformers.conf $(PKG_DB)/filepath.conf $(PKG_DB)/ghc-boot.conf $(PKG_DB)/ghc-heap.conf $(PKG_DB)/unix.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/ghci \
 		ghci
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/ghci/ghci.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghci/ghci.conf
 
-inst/package.conf/pretty.conf : inst/package.conf/deepseq.conf inst/package.conf/ghc-prim.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/pretty.conf : $(PKG_DB)/deepseq.conf $(PKG_DB)/ghc-prim.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/pretty \
 		pretty
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/pretty/pretty.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/pretty/pretty.conf
 
-inst/package.conf/template-haskell.conf : inst/package.conf/ghc-boot-th.conf inst/package.conf/pretty.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/template-haskell.conf : $(PKG_DB)/ghc-boot-th.conf $(PKG_DB)/pretty.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/template-haskell \
 		template-haskell
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/template-haskell/template-haskell.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/template-haskell/template-haskell.conf
 
-inst/package.conf/parsec.conf : inst/package.conf/mtl.conf inst/package.conf/text.conf inst/package.conf/bytestring.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/parsec.conf : $(PKG_DB)/mtl.conf $(PKG_DB)/text.conf $(PKG_DB)/bytestring.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/parsec \
 		parsec
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/parsec/parsec.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/parsec/parsec.conf
 
-inst/package.conf/process.conf : inst/package.conf/directory.conf inst/package.conf/deepseq.conf inst/package.conf/ghcjs-prim.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/process.conf : $(PKG_DB)/directory.conf $(PKG_DB)/deepseq.conf $(PKG_DB)/ghcjs-prim.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/process \
 		process
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/process/process.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/process/process.conf
 
-inst/package.conf/time.conf : inst/package.conf/deepseq.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/time.conf : $(PKG_DB)/deepseq.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/time \
 		time
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/time/time.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/time/time.conf
 
-inst/package.conf/text.conf : inst/package.conf/deepseq.conf inst/package.conf/bytestring.conf inst/package.conf/array.conf inst/package.conf/ghc-prim.conf inst/package.conf/binary.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/text.conf : $(PKG_DB)/deepseq.conf $(PKG_DB)/bytestring.conf $(PKG_DB)/array.conf $(PKG_DB)/ghc-prim.conf $(PKG_DB)/binary.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/text \
 		text
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/text/text.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/text/text.conf
 
-inst/package.conf/mtl.conf : inst/package.conf/transformers.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/mtl.conf : $(PKG_DB)/transformers.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/mtl \
 		mtl
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/mtl/mtl.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/mtl/mtl.conf
 
-inst/package.conf/unix.conf : inst/package.conf/time.conf inst/package.conf/bytestring.conf
-	./build-package.sh $(PKG_DB) \
+$(PKG_DB)/unix.conf : $(PKG_DB)/time.conf $(PKG_DB)/bytestring.conf
+	./build-package.sh $(FULL_PKG_DB) \
 		$(ROOT_DIR)/pkg/unix \
 		unix
-	$(HC_PKG) --global-package-db=$(PKG_DB) register $(ROOT_DIR)/build/unix/unix.conf
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/unix/unix.conf
+
+$(PKG_DB)/ghcjs-th.conf : $(PKG_DB)/template-haskell.conf $(PKG_DB)/ghci.conf
+	./build-package.sh $(FULL_PKG_DB) \
+		$(ROOT_DIR)/pkg/ghcjs-th \
+		ghcjs-th
+	$(HC_PKG) --global-package-db=$(FULL_PKG_DB) register $(ROOT_DIR)/build/ghcjs-th/ghcjs-th.conf
+
 
 clean :
-	rm -fR inst/package.conf
+	rm -fR $(PKG_DB)

--- a/lib/boot/Settings.hs
+++ b/lib/boot/Settings.hs
@@ -1,0 +1,9 @@
+import System.Environment (getArgs)
+
+main = doStuff <$> getArgs <*> (read <$> getContents) >>= putStr
+
+doStuff [key] map = case lookup key map of
+    Just s -> s
+    Nothing -> error $ key ++ " not present"
+doStuff [] _ = error "no lookup key provided"
+doStuff _ _ = error "invalid argument"

--- a/lib/boot/build-package.sh
+++ b/lib/boot/build-package.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -oue pipefail
+# $1 - package db
+# $2 - path to package
+# $3 - package-name
+# HC and HOST_HC are expected env vars.
+PKG_DB=$1; shift
+PKG=$1; shift
+PKG_NAME=$1; shift
+
+BUILD="${PWD}/build/${PKG_NAME}"
+PREFIX="${PWD}/inst"
+mkdir -p "${BUILD}"
+mkdir -p "${PREFIX}"
+
+SETUP_HS=exit
+
+if [[ -f ${PKG}/Setup.hs ]];  then
+    ${HOST_HC} -o ${BUILD}/Setup ${PKG}/Setup.hs
+    SETUP_HS="${BUILD}/Setup"
+elif [[ -f ${PKG}/Setup.lhs ]]; then
+    ${HOST_HC} -o ${BUILD}/Setup ${PKG}/Setup.lhs
+    SETUP_HS="${BUILD}/Setup"
+else
+    SETUP_HS=exit
+fi
+
+cd "$PKG"
+# configure the package
+CFLAGS="-I${PKG} ${CFLAGS}" \
+    ${SETUP_HS} configure --with-ghc=${HC} \
+	--disable-library-stripping \
+	--disable-executable-stripping \
+    --prefix="${PREFIX}" \
+    --package-db=clear \
+    --package-db="${PKG_DB}" \
+    --builddir=${BUILD} \
+    --ipid=${PKG_NAME} \
+    --ghc-option=-Dghcjs_HOST_OS \
+    $@
+
+#cd "${BUILD}"
+# build it.
+CFLAGS="-I${PKG} ${CFLAGS}" \
+    ${SETUP_HS} build --builddir=${BUILD} \
+    --ghc-option=-Dghcjs_HOST_OS #\
+#    --ghc-option=-v \
+#    -v
+# copy the lib, ...
+${SETUP_HS} copy --builddir=${BUILD}
+# and generate the pkg-config file.
+${SETUP_HS} register --builddir=${BUILD} \
+    --gen-pkg-config="${BUILD}/${PKG_NAME}.conf"

--- a/lib/boot/build-package.sh
+++ b/lib/boot/build-package.sh
@@ -26,6 +26,9 @@ else
 fi
 
 cd "$PKG"
+
+sed -i 's/impl(ghcjs)/os(ghcjs)/g' *.cabal
+
 # configure the package
 CFLAGS="-I${PKG} ${CFLAGS}" \
     ${SETUP_HS} configure --with-ghc=${HC} \

--- a/lib/boot/fake-rts.conf
+++ b/lib/boot/fake-rts.conf
@@ -1,0 +1,8 @@
+name: rts
+version: 1.0
+id: rts
+key: rts
+license: BSD-3-Clause
+maintainer: glasgow-haskell-users@haskell.org
+exposed: True
+include-dirs: /Users/angerman/.ghcjs/x86_64-osx-8.6.5-8.6.5/ghcjs/include

--- a/lib/boot/fake-rts.conf
+++ b/lib/boot/fake-rts.conf
@@ -5,4 +5,4 @@ key: rts
 license: BSD-3-Clause
 maintainer: glasgow-haskell-users@haskell.org
 exposed: True
-include-dirs: /Users/angerman/.ghcjs/x86_64-osx-8.6.5-8.6.5/ghcjs/include
+include-dirs: ${pkgroot}/include

--- a/lib/boot/utils/genprimopcode/genprimopcode
+++ b/lib/boot/utils/genprimopcode/genprimopcode
@@ -1,0 +1,7 @@
+#!/bin/bash
+(>&2 echo $@)
+case "$1" in
+    "--make-haskell-source") cat ../../data/Prim.hs;;
+    "--make-haskell-wrappers") cat ../../data/PrimopWrappers.hs;;
+    *) (>&2 echo "Unknown command $1"); exit 1;;
+esac

--- a/src-bin/Haddock.hs
+++ b/src-bin/Haddock.hs
@@ -51,7 +51,6 @@ withGhcjs' libDir flags ghcActs = runGhc (Just libDir) $ do
     }
   env <- liftIO Ghcjs.newGhcjsEnv
   let dynflags'' = Ghcjs.setGhcjsPlatform mempty env [] libDir $
-                   updateWays $ addWay' (WayCustom "js") $
                    Ghcjs.setGhcjsSuffixes False $
                    gopt_unset dynflags' Opt_SplitObjs
   defaultCleanupHandler dynflags'' $ do

--- a/src/Compiler/GhcjsProgram.hs
+++ b/src/Compiler/GhcjsProgram.hs
@@ -260,14 +260,7 @@ setGhcjsSuffixes :: Bool     -- oneshot option, -c
                  -> DynFlags
                  -> DynFlags
 setGhcjsSuffixes oneshot df = df
-    { objectSuf     = mkGhcjsSuf (objectSuf df)
-    , dynObjectSuf  = mkGhcjsSuf (dynObjectSuf df)
-    , hiSuf         = mkGhcjsSuf (hiSuf df)
-    , dynHiSuf      = mkGhcjsSuf (dynHiSuf df)
-    , outputFile    = fmap mkGhcjsOutput (outputFile df)
-    , dynOutputFile = fmap mkGhcjsOutput (dynOutputFile df)
-    , outputHi      = fmap mkGhcjsOutput (outputHi df)
-    , ghcLink       = if oneshot then NoLink else ghcLink df
+    { ghcLink       = if oneshot then NoLink else ghcLink df
     }
 
 
@@ -344,7 +337,6 @@ setupSessionForGhcjs ghcjsSettings = do
   jsEnv <- liftIO newGhcjsEnv
   _ <- setSessionDynFlags
        $ setGhcjsPlatform ghcjsSettings jsEnv [] base
-       $ updateWays $ addWay' (WayCustom "js")
        $ setGhcjsSuffixes False dflags
   pure ()
 

--- a/src/Compiler/Plugins.hs
+++ b/src/Compiler/Plugins.hs
@@ -245,8 +245,8 @@ initPluginsEnv orig_dflags _ = do
          dflags1 { packageFlags   = []
                  , packageDBFlags = hostPackageDBFlags . packageDBFlags $ dflags1
                  , ways           = filter (/= WayCustom "js") (ways dflags1)
-                 , hiSuf          = removeJsPrefix (hiSuf dflags1)
-                 , dynHiSuf       = removeJsPrefix (dynHiSuf dflags1)
+                --  , hiSuf          = removeJsPrefix (hiSuf dflags1)
+                --  , dynHiSuf       = removeJsPrefix (dynHiSuf dflags1)
                  }
   dflags3 <- initDynFlags dflags2
   (dflags, units) <- initPackages dflags3

--- a/src/Compiler/Program.hs
+++ b/src/Compiler/Program.hs
@@ -264,7 +264,6 @@ main' postLoadMode dflags0 args flagWarnings ghcjsSettings native = do
                 then return (Ghcjs.setNativePlatform jsEnv ghcjsSettings baseDir dflags4)
                 else return $
                        Ghcjs.setGhcjsPlatform ghcjsSettings jsEnv js_objs baseDir $
-                       updateWays $ addWay' (WayCustom "js") $
                        Ghcjs.setGhcjsSuffixes {- oneshot -} False dflags4 -- fixme value of oneshot?
 
   let dflags5 = dflags4b { ldInputs = map (FileOption "") objs

--- a/src/Compiler/Utils.hs
+++ b/src/Compiler/Utils.hs
@@ -12,8 +12,6 @@ module Compiler.Utils
     , jsexeExtension
     , addExeExtension
     , exeFileName
-    , mkGhcjsSuf
-    , mkGhcjsOutput
     , substPatterns
       -- * Source code and JS related utilities
     , ghcjsSrcSpan
@@ -100,7 +98,7 @@ exeFileName :: DynFlags -> FilePath
 exeFileName dflags
   | Just s <- outputFile dflags =
       -- unmunge the extension
-      let s' = dropPrefix "js_" (drop 1 $ takeExtension s)
+      let s' = drop 1 $ takeExtension s
 #ifdef WINDOWS
       in if null s' || map toLower s' == "exe"
 #else
@@ -119,28 +117,6 @@ exeFileName dflags
 
 isJsFile :: FilePath -> Bool
 isJsFile = (==".js") . takeExtension
-
-mkGhcjsOutput :: String -> String
-mkGhcjsOutput "" = ""
-mkGhcjsOutput file
-  | null ext         = file
-  | ext == ".js"     = file
-  | ext == ".hi"     = replaceExtension file ".js_hi"
-  | ext == ".o"      = replaceExtension file ".js_o"
-  | ext == ".dyn_hi" = replaceExtension file ".js_dyn_hi"
-  | ext == ".dyn_o"  = replaceExtension file ".js_dyn_o"
-  |  ".js_" `isPrefixOf` ext || "_js_" `isInfixOf` ext = file
-  | otherwise        = replaceExtension file (".js_" ++ drop 1 ext)
-  where
-    ext = takeExtension file
-
-mkGhcjsSuf :: String -> String
-mkGhcjsSuf "o"      = "js_o"
-mkGhcjsSuf "hi"     = "js_hi"
-mkGhcjsSuf "dyn_o"  = "js_dyn_o"
-mkGhcjsSuf "dyn_hi" = "js_dyn_hi"
-mkGhcjsSuf xs | "js_" `isPrefixOf` xs || "_js_" `isInfixOf` xs = xs
-mkGhcjsSuf xs       = "js_" ++ xs -- is this correct?
 
 getEnvMay :: String -> IO (Maybe String)
 getEnvMay xs = fmap Just (getEnv xs)

--- a/src/Gen2/Archive.hs
+++ b/src/Gen2/Archive.hs
@@ -1,19 +1,22 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, TupleSections #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, TupleSections, GeneralizedNewtypeDeriving, OverloadedStrings #-}
 
 module Gen2.Archive ( Entry(..), Index, IndexEntry(..), Meta(..)
                     , buildArchive
                     , readMeta, readIndex
-                    , readSource, readAllSources
+                    , readSource, readAllData, readAllSources
                     , readObject, withObject, withAllObjects
                     ) where
 
 import           Control.Monad
+import           Data.Semigroup (Semigroup)
+import           Control.Applicative ((<|>))
 
 import           Data.Binary
 import           Data.Binary.Get
 import           Data.Binary.Put
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Char8 as C
 import           Data.Data
 import           Data.Int
 import           Data.Text (Text)
@@ -25,7 +28,7 @@ import           System.IO
 
 import           Module
 
-import           Gen2.Object ( versionTag, versionTagLength )
+import           Gen2.Object ( versionTag, versionTagLength, readDeps, depsModule )
 
 -- entry, offset in data section, length
 type Index = [IndexEntry]
@@ -73,80 +76,220 @@ buildArchive meta entries =
     entries' = mconcat (map snd entries)
 
 readMeta :: FilePath -> IO Meta
-readMeta file = withFile file ReadMode $ \h -> do
-  sections <- hReadHeader ("readMeta " ++ file) h
-  hSeek h RelativeSeek (toInteger $ sectionIndex sections)
-  m <- B.hGet h (fromIntegral $ sectionMeta sections)
-  return $! runGet get m
+readMeta _ = return $ Meta []
+-- withFile file ReadMode $ \h -> do
+--   sections <- hReadHeader ("readMeta " ++ file) h
+--   hSeek h RelativeSeek (toInteger $ sectionIndex sections)
+--   m <- B.hGet h (fromIntegral $ sectionMeta sections)
+--   return $! runGet get m
 
 readIndex :: FilePath -> IO Index
-readIndex file =
-  withArchive "readIndex" file $ \_sections index _h -> return index
+readIndex _ = undefined
 
 readSource :: FilePath -> FilePath -> IO ByteString
-readSource source file = withArchive "readSource" file $
-  withEntry ("readSource " ++ file)
-            ("source file " ++ source)
-            selectSrc
-            (\h l -> B.hGet h $ fromIntegral l)
-  where
-    selectSrc (JsSource src) = src == source
-    selectSrc _              = False
+readSource source file = undefined
+-- withArchive "readSource" file $
+--   withEntry ("readSource " ++ file)
+--             ("source file " ++ source)
+--             selectSrc
+--             (\h l -> B.hGet h $ fromIntegral l)
+--   where
+--     selectSrc (JsSource src) = src == source
+--     selectSrc _              = False
+
+
+readAllData :: FilePath -> IO [ByteString]
+readAllData file = return [] -- withAllObjects file $ \_ h l -> B.hGet h (fromIntegral l)
 
 readAllSources :: FilePath -> IO [(FilePath, ByteString)]
-readAllSources file = withArchive "readAllSources" file $ \sections index h ->
-  forM [ (o, l, src) | IndexEntry (JsSource src) o l <- index ] $ \(o, l, src) -> do
-    hSeek h AbsoluteSeek (fromIntegral $ dataSectionStart sections + fromIntegral o)
-    (src,) <$> B.hGet h (fromIntegral l)
+readAllSources file = undefined
+-- withArchive "readAllSources" file $ \archive h ->
+--   forM [ (o, l, src) | IndexEntry (JsSource src) o l <- index ] $ \(o, l, src) -> do
+--     hSeek h AbsoluteSeek (fromIntegral $ dataSectionStart sections + fromIntegral o)
+--     (src,) <$> B.hGet h (fromIntegral l)
 
 readObject :: ModuleName -> FilePath -> IO ByteString
-readObject m file = withArchive "readObject" file $
-  withModuleObject ("readObject " ++ file) m (\h l -> B.hGet h $ fromIntegral l)
+readObject m file = do
+  putStrLn ("Archive::readObject: " ++ file)
+  withArchive "readObject" file $
+    withModuleObject ("readObject " ++ file) m (\h l -> B.hGet h $ fromIntegral l)
 
 -- | seeks to the starting position of the object in the file
 withObject :: ModuleName -> FilePath -> (Handle -> Int64 -> IO a) -> IO a
 withObject m file f = withArchive "withObject" file $
   withModuleObject ("withObject " ++ file) m f
 
-withAllObjects :: FilePath -> (ModuleName -> Handle -> Int64 -> IO a) -> IO [a]
-withAllObjects file f = withArchive "withAllObjects" file $ \sections index h ->
-  forM [ (o, l, mn) | IndexEntry (Object mn) o l <- index ] $ \(o, l, mn) -> do
-    hSeek h AbsoluteSeek (fromIntegral $ dataSectionStart sections + fromIntegral o)
-    f (mkModuleName (T.unpack mn)) h l
+newtype Archive = Archive [ArchiveEntry]
+  deriving (Eq, Show, Semigroup, Monoid)
+
+data ArchiveEntry = ArchiveEntry
+    { filename :: String       -- ^ File name.
+    , filemodule :: String     -- ^ File module name.
+    , filetime :: Int          -- ^ File modification time.
+    , fileown  :: Int          -- ^ File owner.
+    , filegrp  :: Int          -- ^ File group.
+    , filemode :: Int          -- ^ File mode.
+    , fileoffset :: Int        -- ^ File offset.
+    , filesize :: Int          -- ^ File size.
+    } deriving (Eq, Show)
+
+getArchMagic :: Get ()
+getArchMagic = do
+  magic <- liftM C.unpack $ getByteString 8
+  if magic /= "!<arch>\n"
+    then fail $ "Invalid magic number " ++ show magic
+    else return ()
+
+getBSDArchEntries :: Get [ArchiveEntry]
+getBSDArchEntries = do
+  empty <- isEmpty
+  if empty then
+      return []
+   else do
+      name    <- getByteString 16
+      when ('/' `C.elem` name && C.take 3 name /= "#1/") $
+        fail "Looks like GNU Archive"
+      time    <- getPaddedInt <$> getByteString 12
+      own     <- getPaddedInt <$> getByteString 6
+      grp     <- getPaddedInt <$> getByteString 6
+      mode    <- getPaddedInt <$> getByteString 8
+      st_size <- getPaddedInt <$> getByteString 10
+      end     <- getByteString 2
+      when (end /= "\x60\x0a") $
+        fail ("[BSD Archive] Invalid archive header end marker for name: " ++
+              C.unpack name)
+      off1    <- liftM fromIntegral bytesRead :: Get Int
+      -- BSD stores extended filenames, by writing #1/<length> into the
+      -- name field, the first @length@ bytes then represent the file name
+      -- thus the payload size is filesize + file name length.
+      name    <- if C.unpack (C.take 3 name) == "#1/" then
+                      liftM (C.unpack . C.takeWhile (/= '\0')) (getByteString $ read $ C.unpack $ C.drop 3 name)
+                  else
+                      return $ C.unpack $ C.takeWhile (/= ' ') name
+      off2    <- liftM fromIntegral bytesRead :: Get Int
+      file <- getByteString (st_size - (off2 - off1)) -- file size
+      -- data sections are two byte aligned (see Trac #15396)
+      when (odd st_size) $
+        void (getByteString 1)
+
+      rest    <- getBSDArchEntries
+      let mod = T.unpack . depsModule $ readDeps name (B.fromStrict file)
+      return $ (ArchiveEntry name mod time own grp mode off2 (st_size - (off2 - off1))) : rest
+
+getGNUArchEntries :: Maybe ArchiveEntry -> Get [ArchiveEntry]
+getGNUArchEntries extInfo = do
+  empty <- isEmpty
+  if empty
+    then return []
+    else
+    do
+      name    <- getByteString 16
+      time    <- getPaddedInt <$> getByteString 12
+      own     <- getPaddedInt <$> getByteString 6
+      grp     <- getPaddedInt <$> getByteString 6
+      mode    <- getPaddedInt <$> getByteString 8
+      st_size <- getPaddedInt <$> getByteString 10
+      end     <- getByteString 2
+      when (end /= "\x60\x0a") $
+        fail ("[BSD Archive] Invalid archive header end marker for name: " ++
+              C.unpack name)
+      off <- liftM fromIntegral bytesRead :: Get Int
+      file <- getByteString st_size
+      -- data sections are two byte aligned (see Trac #15396)
+      when (odd st_size) $
+        void (getByteString 1)
+      name <- return . C.unpack $
+        if C.unpack (C.take 1 name) == "/"
+        then case C.takeWhile (/= ' ') name of
+                name@"/"  -> name               -- symbol table
+                name@"//" -> name               -- extendedn file names table
+                name      -> getExtName extInfo (read . C.unpack $ C.drop 1 name) file
+        else C.takeWhile (/= '/') name
+      let mod = T.unpack . depsModule $ readDeps name (B.fromStrict file)
+      case name of
+        "/"  -> getGNUArchEntries extInfo
+        "//" -> getGNUArchEntries (Just (ArchiveEntry name mod time own grp mode off st_size))
+        _    -> (ArchiveEntry name mod time own grp mode off st_size :) <$> getGNUArchEntries extInfo
+  where
+    getExtName :: Maybe ArchiveEntry -> Int -> C.ByteString -> C.ByteString
+    getExtName Nothing _ _ = error "Invalid extended filename reference."
+    getExtName (Just info) offset filedata = C.takeWhile (/= '/') . C.drop offset $ filedata
+
+
+-- | Archives have numeric values padded with '\x20' to the right.
+getPaddedInt :: C.ByteString -> Int
+getPaddedInt = read . C.unpack . C.takeWhile (/= '\x20')
+
+
+getArch :: Get Archive
+getArch = Archive <$> do
+  getArchMagic
+  getBSDArchEntries <|> getGNUArchEntries Nothing
+
+-- withAllObjects :: FilePath -> (ModuleName -> Handle -> Int64 -> IO a) -> IO [a]
+-- withAllObjects file f = do
+--   putStrLn ("Archive::withAllObjects: " ++ file)
+--   withArchive "withAllObjects" file $ \sections index h ->
+--     forM [ (o, l, mn) | IndexEntry (Object mn) o l <- index ] $ \(o, l, mn) -> do
+--       hSeek h AbsoluteSeek (fromIntegral $ dataSectionStart sections + fromIntegral o)
+--       f (mkModuleName (T.unpack mn)) h l
+
+withAllObjects :: FilePath -- ^ ar Archive (BSD Format)
+               -> (ModuleName -- ^ Name of the module. Something like archive.a(object.o)
+                -> Handle -- ^ handle with proper offset
+                -> Int64 -- ^ length
+                -> IO a) -- ^ callback to apply to each element in the archive
+               -> IO [a]
+withAllObjects file f = do
+  putStrLn $ "Archive::withAllObjects:" ++ file
+  withArchive "withAllObjects" file $ \(Archive archive) h ->
+    forM [ (o, l, file ++ "(" ++ fn ++ ")")
+         | ArchiveEntry { filename = fn, fileoffset = o, filesize = l } <- archive ] $ \(o, l, mn) -> do
+          hSeek h AbsoluteSeek (fromIntegral o)
+          f (mkModuleName mn) h (fromIntegral l)
+
 
 ---------------------------------------------------------------------------------
 
-withArchive :: String -> FilePath -> (Sections -> Index -> Handle -> IO a) -> IO a
-withArchive name file f = withFile file ReadMode $ \h -> do
-  let name' = name ++ " " ++ file
-  sections <- hReadHeader name' h
-  index <- hReadIndex name' sections h
-  f sections index h
+-- withArchive :: String -> FilePath -> (Sections -> Index -> Handle -> IO a) -> IO a
+-- withArchive name file f = withFile file ReadMode $ \h -> do
+--   let name' = name ++ " " ++ file
+--   sections <- hReadHeader name' h
+--   index <- hReadIndex name' sections h
+--   f sections index h
+
+withArchive :: String    -- name
+            -> FilePath  --
+            -> (Archive -> Handle -> IO a)
+            -> IO a
+withArchive name file f = do
+  arch <- runGet getArch <$> B.readFile file
+  withFile file ReadMode $ \h -> do
+    f arch h
 
 -- | seeks to start of entry data in file, then runs the action
 --   exactly one matching entry is expected
 withEntry :: String -> String
-          -> (Entry -> Bool) -> (Handle -> Int64 -> IO a)
-          -> Sections -> Index -> Handle
+          -> (ArchiveEntry -> Bool) -> (Handle -> Int64 -> IO a)
+          -> Archive -> Handle
           -> IO a
-withEntry name entryName p f sections index h =
-  case filter (p . ieEntry) index of
+withEntry name entryName p f (Archive archive) h =
+  case filter p archive of
     [] -> error (name ++ ": cannot find " ++ entryName)
-    [IndexEntry _ o l] -> do
-      hSeek h AbsoluteSeek (dataSectionStart sections + toInteger o)
+    [ArchiveEntry { fileoffset = o, filesize = l }] -> do
+      hSeek h AbsoluteSeek (fromIntegral o)
       f h (fromIntegral l)
     _ -> error (name ++ ": multiple matches for " ++ entryName)
 
 withModuleObject :: String -> ModuleName -> (Handle -> Int64 -> IO a)
-                 -> Sections -> Index -> Handle
+                 -> Archive -> Handle
                  -> IO a
 withModuleObject name m f =
   withEntry name ("object for module " ++ ms) selectEntry f
   where
     ms = moduleNameString m
-    mt = T.pack ms
-    selectEntry (Object m') = mt == m'
-    selectEntry _           = False
+    selectEntry (ArchiveEntry { filemodule = m' }) = ms == m'
+    selectEntry _                                = False
 
 -- | expects Handle to be positioned at the start of the header
 --   Handle is positioned at start of index after return

--- a/src/Gen2/DynamicLinking.hs
+++ b/src/Gen2/DynamicLinking.hs
@@ -91,7 +91,7 @@ ghcjsLinkJsLib settings jsFiles dflags hpt
   | Just jsLib <- gsLinkJsLib settings = do
       let profSuff | WayProf `elem` ways dflags = "_p"
                    | otherwise                  = ""
-          libFileName    = ("lib" ++ jsLib ++ profSuff) <.> "js_a"
+          libFileName    = ("lib" ++ jsLib ++ profSuff) <.> "a"
           inOutputDir file =
             maybe file
                   (</>file)
@@ -112,7 +112,7 @@ ghcjsLinkJsLib settings jsFiles dflags hpt
       -- generate one when building with --dynamic-too. Just write an empty file
       when (gopt Opt_BuildDynamicToo dflags || WayDyn `elem` ways dflags) $ do
         let sharedLibFileName =
-              "lib" ++ jsLib ++ "-ghcjs" ++ Info.getCompilerVersion ++ profSuff <.> "js_so"
+              "lib" ++ jsLib ++ "-ghcjs" ++ Info.getCompilerVersion ++ profSuff <.> "so"
             sharedOutputFile = inOutputDir sharedLibFileName
         -- keep strip happy
         BS.writeFile sharedOutputFile =<< BS.readFile (topDir dflags </> "empty.o")

--- a/src/Gen2/Object.hs
+++ b/src/Gen2/Object.hs
@@ -362,7 +362,9 @@ hReadDeps :: String -> Handle -> IO Deps
 hReadDeps name h = do
   mhdr <- getHeader <$> B.hGet h headerLength
   case mhdr of
-    Left err -> error ("hReadDeps: not a valid GHCJS object: " ++ name ++ "\n    " ++ err)
+    Left err -> do
+      putStrLn ("hReadDeps: not a valid GHCJS object: " ++ name ++ "\n    " ++ err)
+      return $ Deps (Package "C") "C" mempty mempty (array (0,1) [])
     Right hdr -> do
       hSeek h RelativeSeek (fromIntegral $ symbsLen hdr)
       getDepsSection name <$> B.hGet h (fromIntegral $ depsLen hdr)
@@ -371,7 +373,9 @@ hReadDeps name h = do
 readDeps :: String -> ByteString -> Deps
 readDeps name bs =
   case getHeader bs of
-    Left err -> error ("readDeps: not a valid GHCJS object: " ++ name ++ "\n   " ++ err)
+    Left err ->
+      -- trace ("hReadDeps: not a valid GHCJS object: " ++ name ++ "\n    " ++ err)
+      Deps (Package "C") "C" mempty mempty (array (0,1) [])
     Right hdr ->
       let depsStart = fromIntegral headerLength + fromIntegral (symbsLen hdr)
       in  getDepsSection name (B.drop depsStart bs)

--- a/src/Gen2/Shim.hs
+++ b/src/Gen2/Shim.hs
@@ -136,13 +136,13 @@ jsCppOpts opts = filter (/="-traditional") (removeCabalMacros opts)
 readShimsArchive :: DynFlags -> FilePath -> IO B.ByteString
 readShimsArchive dflags archive = do
   meta <- Ar.readMeta archive
-  srcs <- Ar.readAllSources archive
+  srcs <- Ar.readAllData archive
   let s       = settings dflags
       s1      = s { sPgm_P = (fst (sPgm_P s), jsCppPgmOpts (snd $ sPgm_P s))
                   , sOpt_P = jsCppOpts (Ar.metaCppOptions meta ++ sOpt_P s)
                   }
       dflags1 = dflags { settings = s1 }
-  srcs' <- forM srcs $ \(_filename, b) -> do
+  srcs' <- forM srcs $ \b -> do
     infile  <- FileCleanup.newTempName dflags FileCleanup.TFL_CurrentModule "jspp"
     outfile <- FileCleanup.newTempName dflags FileCleanup.TFL_CurrentModule "jspp"
     BL.writeFile infile b

--- a/utils/dist-newstyle-wrapper.sh
+++ b/utils/dist-newstyle-wrapper.sh
@@ -48,7 +48,7 @@ pushd "${GHCJS}/build" > /dev/null
 GHCJSVER="${GHCJS:6}" # drop the 'ghcjs-' prefix
 GHCLIBVER=`ghcjs/ghcjs -B/ --numeric-ghc-version`
 DISTDIR="$PWD"
-LIBDIR="$HOME/.ghcjs/${ARCH}-${GHCJSVER}-${GHCLIBVER}/ghcjs"
+LIBDIR="$SOURCEDIR/../lib/boot/inst/lib"
 popd > /dev/null
 popd > /dev/null
 popd > /dev/null

--- a/utils/pkg-input/ghc-api-ghcjs/includes/ghc_boot_platform.h
+++ b/utils/pkg-input/ghc-api-ghcjs/includes/ghc_boot_platform.h
@@ -3,7 +3,7 @@
 
 #define BuildPlatform_NAME  "x86_64-unknown-linux"
 #define HostPlatform_NAME   "x86_64-unknown-linux"
-#define TargetPlatform_NAME "x86_64-unknown-linux"
+#define TargetPlatform_NAME "x86_64-unknown-ghcjs"
 
 #define x86_64_unknown_linux_BUILD 1
 #define x86_64_unknown_linux_HOST 1


### PR DESCRIPTION
This is a stab at making ghcjs less reliant on custom tools/formats. The idea is that we can use `ghcjs` like any other `hc` with cabal. This can be see in the Makefile that is supposed to replace the custom Boot.hs, with minimal customization to the toolchains.

Changes to ghcjs's Archive/Linker logic allow us to use regular GNU and BSD archives. A lot of code for this has been lifted from the `Ar` module in ghc; which sadly can not be re-used as the
interfaces differ.

NOTE: This is supposed to be more of a proof-of-concept than anything tangible right now.