### PR TITLE
Update GHCConstantsHaskellType.hs

### DIFF
--- a/lib/boot/data/platformConstants
+++ b/lib/boot/data/platformConstants
@@ -1,6 +1,5 @@
 PlatformConstants {
-    pc_platformConstants = ()
-    , pc_CONTROL_GROUP_CONST_291 = 291
+      pc_CONTROL_GROUP_CONST_291 = 291
     , pc_STD_HDR_SIZE = 1
     , pc_PROF_HDR_SIZE = 2
     , pc_BLOCK_SIZE = 4096

--- a/lib/ghc/includes/GHCConstantsHaskellType.hs
+++ b/lib/ghc/includes/GHCConstantsHaskellType.hs
@@ -1,6 +1,5 @@
 data PlatformConstants = PlatformConstants {
-    pc_platformConstants :: ()
-    , pc_CONTROL_GROUP_CONST_291 :: Int
+      pc_CONTROL_GROUP_CONST_291 :: Int
     , pc_STD_HDR_SIZE :: Int
     , pc_PROF_HDR_SIZE :: Int
     , pc_BLOCK_SIZE :: Int


### PR DESCRIPTION
platformConstants seems to not be in 8.10